### PR TITLE
Revert "Fix typos/grammar in README & code comments"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ processor verification. It currently supports the following features:
 - Test suite to stress test MMU
 - Support sub-programs and random program calls
 - Random forward/backward branch instructions
-- Supports mixing directed instructions with random instruction stream
+- Support mix directed instruciton with random instruction stream
 
 ## Getting Started
 
 ### Prerequisites
 
 To be able to run the instruction generator, you need to have an RTL simulator
-which supports SystemVerilog and UVM 1.2. This generator has been verified with
+which supports Systemverilog and UVM 1.2. This generator has been verified with
 Synopsys VCS and Cadence Incisive/Xcelium simulator. Please make sure the EDA
 tool environment is properly setup before running the generator.
 

--- a/src/riscv_instr_pkg.sv
+++ b/src/riscv_instr_pkg.sv
@@ -88,7 +88,7 @@ package riscv_instr_pkg;
   } riscv_reg_t;
 
   // Enum for 32 bits instruction opcode
-  // >32b instructions are not supported yet
+  // >32b instrunctions are not supported yet
   typedef enum bit[6:0] {
     OP_LOAD        = 7'b0000011,
     OP_LOAD_FP     = 7'b0000111,

--- a/src/riscv_page_table_list.sv
+++ b/src/riscv_page_table_list.sv
@@ -104,7 +104,7 @@ class riscv_page_table_list#(satp_mode_t MODE = SV39) extends uvm_object;
   // Take SV39 for example: (PTE_SIZE = 8B)
   // Table size is 4KB, PTE_SIZE=8B, entry count = 4K/8 = 512
   // Level 2: Root table, 2 entries, PTE[0] and PTE[1] is non-leaf PTE, PTE[2] is leaf PTE, all
-  //          other PTEs are invalid, totalling 1 page table with 3 PTEs at this level.
+  //          other PTEs are invalid, totally 1 page table with 3 PTEs at this level.
   // Level 1: Two page tables, map to PTE[0] and PTE[1] of the root table.
   //          Each table has 512 entries, PTE[0], PTE[1] are non-leaf PTE, cover 4MB memory
   //          space. PTE[2:511] are leaf PTE, cover 510 * 2MB memory space.
@@ -113,7 +113,7 @@ class riscv_page_table_list#(satp_mode_t MODE = SV39) extends uvm_object;
   // In summary, 7(1+2+4) tables are needed for SV39.
   // Similarly, 3 (1+2) page tables for SV32, 15 (1 + 2 + 4 + 8) page tables for SV48.
   // Note:
-  // - The number of randomization call is optimized to improve performance
+  // - The number of randomization call is optmized to improve performance
   // - PPN assignment is done at program run time
   virtual function void randomize_page_table();
     int pte_index;
@@ -196,7 +196,7 @@ class riscv_page_table_list#(satp_mode_t MODE = SV39) extends uvm_object;
     `DV_CHECK_RANDOMIZE_FATAL(exception_cfg)
     `DV_CHECK_RANDOMIZE_WITH_FATAL(illegal_pte,
                                    !(xwr inside {NEXT_LEVEL_PAGE, R_W_EXECUTE_PAGE});)
-    // Wrong privilege mode setting
+    // Wrong privielge mode setting
     if(exception_cfg.allow_privileged_mode_exception) begin
       pte.u = ~pte.u;
     end


### PR DESCRIPTION
Reverts google/riscv-dv#8 because CLA not signed