### PR TITLE
Give error for mutually exclusive between -co, and -so argument

### DIFF
--- a/run.py
+++ b/run.py
@@ -116,6 +116,9 @@ def gen(test_list, simulator, simulator_yaml, output_dir, sim_only,
     sim_opts       : Simulation options for the generator
     timeout_s      : Timeout limit in seconds
   """
+  # Mutually exclusive options between compile_only and sim_only
+  if compile_only and sim_only:
+    logging.error("argument -co is not allowed with argument -so")
   # Setup the compile and simulation command for the generator
   compile_cmd = []
   sim_cmd = ""


### PR DESCRIPTION
I make PR to give error for mutually exclusive between `-co`, and `-so` argument