### PR TITLE
Re-organize data page generation

### DIFF
--- a/scripts/link.ld
+++ b/scripts/link.ld
@@ -23,7 +23,11 @@ SECTIONS
   . = ALIGN(0x1000);
   .tohost : { *(.tohost) }
   . = ALIGN(0x1000);
+  .page_table : { *(.page_table) }
   .data : { *(.data) }
+  .user_stack : { *(.user_stack) }
+  .kernel_data : { *(.kernel_data) }
+  .kernel_stack : { *(.kernel_stack) }
   .bss : { *(.bss) }
   _end = .;
 }

--- a/setting/riscv_core_setting.sv
+++ b/setting/riscv_core_setting.sv
@@ -44,48 +44,6 @@ bit support_umode_trap = 0;
 // Support sfence.vma instruction
 bit support_sfence = 1;
 
-// Cache line size (in bytes)
-// If processor does not support caches, set to XLEN/8
-int dcache_line_size_in_bytes = 128;
-
-// Number of data section
-// For processor that doesn't have data TLB, this can be set to 1
-// For processor that supports data TLB, this should be set to be larger than the number
-// of entries of dTLB to cover dTLB hit/miss scenario
-int num_of_data_pages = 40;
-
-// Data section byte size
-// For processor with no dTLB and data cache, keep the value below 10K
-// For processor with dTLB support, set it to the physical memory size that covers one entry
-// of the dTLB
-int data_page_size = 4096;
-int data_page_alignment = $clog2(data_page_size);
-
-// The maximum data section byte size actually used by load/store instruction
-// Set to this value to be smaller than data_page_size. If there's data cache in the system,
-// this value should be set large enough to be able to hit cache hit/miss scenario within a data
-// section. Don't set this to too big as it will introduce a very large binary.
-int max_used_data_page_size = 512;
-
-// Stack section word length
-int stack_len = 5000;
-
-//-----------------------------------------------------------------------------
-// Kernel section setting, used by supervisor mode programs
-//-----------------------------------------------------------------------------
-
-// Number of kernel data pages
-int num_of_kernel_data_pages = 5;
-
-// Byte size of kernel data pages
-int kernel_data_page_size = 4096;
-
-// Kernel Stack section word length
-int kernel_stack_len = 5000;
-
-// Number of instructions for each kernel program
-int kernel_program_instr_cnt = 400;
-
 // ----------------------------------------------------------------------------
 // Previleged CSR implementation
 // ----------------------------------------------------------------------------

--- a/src/riscv_amo_instr_lib.sv
+++ b/src/riscv_amo_instr_lib.sv
@@ -15,7 +15,7 @@
  */
 
 // Base class for AMO instruction stream
-class riscv_amo_base_instr_stream extends riscv_directed_instr_stream;
+class riscv_amo_base_instr_stream extends riscv_mem_access_stream;
 
   rand int unsigned  num_amo;
   rand int unsigned  num_mixed_instr;
@@ -23,6 +23,7 @@ class riscv_amo_base_instr_stream extends riscv_directed_instr_stream;
   rand riscv_reg_t   rs1_reg;
   riscv_reg_t        reserved_rd[$];
   rand int unsigned  data_page_id;
+  rand int           max_load_store_offset;
 
   // User can specify a small group of available registers to generate various hazard condition
   rand riscv_reg_t   avail_regs[];
@@ -70,10 +71,10 @@ class riscv_amo_base_instr_stream extends riscv_directed_instr_stream;
                                    pseudo_instr_name == LA;
                                    rd == rs1_reg;,
                                    "Cannot randomize la_instr")
-    if(access_u_mode_mem) begin
-      la_instr.imm_str = $sformatf("data_page_%0d+%0d", data_page_id, base);
+    if(kernel_mode) begin
+      la_instr.imm_str = cfg.s_mem_region[data_page_id].name;
     end else begin
-      la_instr.imm_str = $sformatf("kernel_data_page_%0d+%0d", data_page_id, base);
+      la_instr.imm_str = cfg.mem_region[data_page_id].name;
     end
     instr_list.push_front(la_instr);
   endfunction

--- a/src/riscv_data_page_gen.sv
+++ b/src/riscv_data_page_gen.sv
@@ -23,6 +23,7 @@ class riscv_data_page_gen extends uvm_object;
 
   riscv_instr_gen_config  cfg;
   string                  data_page_str[$];
+  mem_region_t          mem_region_setting[$];
 
   `uvm_object_utils(riscv_data_page_gen)
 
@@ -48,30 +49,48 @@ class riscv_data_page_gen extends uvm_object;
     end
   endfunction
 
-  // Generate the assembly code for the data section
+  // Generate data pages for all memory regions
   function void gen_data_page(data_pattern_t pattern, bit is_kernel = 1'b0);
     string tmp_str;
     bit [7:0] tmp_data[];
     int page_cnt;
     int page_size;
     data_page_str = {};
-    page_cnt = is_kernel ? riscv_instr_pkg::num_of_kernel_data_pages :
-                           riscv_instr_pkg::num_of_data_pages;
-    page_size = is_kernel ? riscv_instr_pkg::kernel_data_page_size :
-                            riscv_instr_pkg::data_page_size;
-    for(int section_idx = 0; section_idx < page_cnt; section_idx++) begin
-      data_page_str.push_back(".data");
-      if(is_kernel) begin
-        data_page_str.push_back($sformatf("kernel_data_page_%0d:", section_idx));
-      end else begin
-        data_page_str.push_back($sformatf("data_page_%0d:", section_idx));
+    if (is_kernel) begin
+      mem_region_setting = cfg.s_mem_region;
+    end else begin
+      mem_region_setting = cfg.mem_region;
+    end
+    if (is_kernel) begin
+      // All kernel data pages in the same section
+      data_page_str.push_back(".pushsection .kernel_data,\"aw\",@progbits;");
+    end
+    foreach (mem_region_setting[i]) begin
+      `uvm_info(`gfn, $sformatf("Generate data section: %0s size:0x%0x  xwr:0x%0x]",
+                                mem_region_setting[i].name,
+                                mem_region_setting[i].size_in_bytes,
+                                mem_region_setting[i].xwr), UVM_LOW)
+      if (!is_kernel) begin
+        data_page_str.push_back($sformatf(".pushsection .%0s,\"aw\",@progbits;",
+                                          mem_region_setting[i].name));
       end
-      data_page_str.push_back($sformatf(".align %0d", riscv_instr_pkg::data_page_alignment));
+      data_page_str.push_back($sformatf("%0s:", mem_region_setting[i].name));
+      page_size = mem_region_setting[i].size_in_bytes;
       for(int i = 0; i < page_size; i+= 32) begin
-        gen_data(.idx(i), .pattern(pattern), .num_of_bytes(32), .data(tmp_data));
+        if (page_size-i >= 32) begin
+          gen_data(.idx(i), .pattern(pattern), .num_of_bytes(32), .data(tmp_data));
+        end else begin
+          gen_data(.idx(i), .pattern(pattern), .num_of_bytes(page_size-i), .data(tmp_data));
+        end
         tmp_str = format_string($sformatf(".word %0s", format_data(tmp_data)), LABEL_STR_LEN);
         data_page_str.push_back(tmp_str);
       end
+      if (!is_kernel) begin
+        data_page_str.push_back(".popsection;");
+      end
+    end
+    if (is_kernel) begin
+      data_page_str.push_back(".popsection;");
     end
   endfunction
 

--- a/src/riscv_directed_instr_lib.sv
+++ b/src/riscv_directed_instr_lib.sv
@@ -40,6 +40,27 @@ class riscv_directed_instr_stream extends riscv_rand_instr_stream;
 
 endclass
 
+// Base class for memory access stream
+class riscv_mem_access_stream extends riscv_directed_instr_stream;
+
+  int             max_data_page_id;
+  mem_region_t    data_page[$];
+  string          label;
+
+  `uvm_object_utils(riscv_mem_access_stream)
+  `uvm_object_new
+
+  function void pre_randomize();
+    if(kernel_mode) begin
+      data_page = cfg.s_mem_region;
+    end else begin
+      data_page = cfg.mem_region;
+    end
+    max_data_page_id = data_page.size();
+  endfunction
+
+endclass
+
 // Create a infinte zero instruction loop, test if we can interrupt or
 // enter debug mode while core is executing this loop
 class riscv_infinte_loop_instr extends riscv_directed_instr_stream;

--- a/src/riscv_instr_gen_config.sv
+++ b/src/riscv_instr_gen_config.sv
@@ -69,6 +69,36 @@ class riscv_instr_gen_config extends uvm_object;
   bit                    check_misa_init_val = 1'b0;
   bit                    check_xstatus = 1'b1;
 
+
+  //-----------------------------------------------------------------------------
+  //  User space memory region and stack setting
+  //-----------------------------------------------------------------------------
+
+  mem_region_t mem_region[$] = '{
+    '{name:"region_0", size_in_bytes: 4096,      xwr: 3'b111},
+    '{name:"region_1", size_in_bytes: 4096 * 4,  xwr: 3'b111},
+    '{name:"region_2", size_in_bytes: 4096 * 2,  xwr: 3'b111},
+    '{name:"region_3", size_in_bytes: 512,       xwr: 3'b111},
+    '{name:"region_4", size_in_bytes: 4096,      xwr: 3'b111}
+  };
+
+  // Stack section word length
+  int stack_len = 5000;
+
+  //-----------------------------------------------------------------------------
+  // Kernel section setting, used by supervisor mode programs
+  //-----------------------------------------------------------------------------
+
+  mem_region_t s_mem_region[$] = '{
+    '{name:"s_region_0", size_in_bytes: 4096, xwr: 3'b111},
+    '{name:"s_region_1", size_in_bytes: 4096, xwr: 3'b111}};
+
+  // Kernel Stack section word length
+  int kernel_stack_len = 4000;
+
+  // Number of instructions for each kernel program
+  int kernel_program_instr_cnt = 400;
+
   //-----------------------------------------------------------------------------
   // Instruction list based on the config, generate by build_instruction_template
   //-----------------------------------------------------------------------------

--- a/src/riscv_instr_pkg.sv
+++ b/src/riscv_instr_pkg.sv
@@ -25,6 +25,13 @@ package riscv_instr_pkg;
 
   `define include_file(f) `include `"f`"
 
+  // Data section setting
+  typedef struct {
+    string         name;
+    int unsigned   size_in_bytes;
+    bit [2:0]      xwr; // Excutable,Writable,Readale
+  } mem_region_t;
+
   typedef enum bit [3:0] {
     BARE = 4'b0000,
     SV32 = 4'b0001,

--- a/src/riscv_instr_stream.sv
+++ b/src/riscv_instr_stream.sv
@@ -121,7 +121,9 @@ class riscv_instr_stream extends uvm_object;
       foreach(insert_instr_position[i]) {
         insert_instr_position[i] inside {[0:current_instr_cnt-1]};
       })
-    insert_instr_position.sort();
+    if (insert_instr_position.size() > 0) begin
+      insert_instr_position.sort();
+    end
     if(contained) begin
       insert_instr_position[0] = 0;
       if(new_instr_cnt > 1)
@@ -150,9 +152,7 @@ endclass
 class riscv_rand_instr_stream extends riscv_instr_stream;
 
   riscv_instr_gen_config  cfg;
-  bit                     access_u_mode_mem = 1'b1;
-  int                     max_load_store_offset;
-  int                     max_data_page_id;
+  bit                     kernel_mode;
   riscv_instr_name_t      allowed_instr[$];
 
   // Some additional reserved registers that should not be used as rd register
@@ -175,16 +175,6 @@ class riscv_rand_instr_stream extends riscv_instr_stream;
     for(int i = 0; i < instr_cnt; i++) begin
       instr = riscv_instr_base::type_id::create($sformatf("instr_%0d", i));
       instr_list.push_back(instr);
-    end
-  endfunction
-
-  function void pre_randomize();
-    if(access_u_mode_mem) begin
-      max_load_store_offset = riscv_instr_pkg::data_page_size;
-      max_data_page_id = riscv_instr_pkg::num_of_data_pages;
-    end else begin
-      max_load_store_offset = riscv_instr_pkg::kernel_data_page_size;
-      max_data_page_id = riscv_instr_pkg::num_of_kernel_data_pages;
     end
   endfunction
 

--- a/src/riscv_load_store_instr_lib.sv
+++ b/src/riscv_load_store_instr_lib.sv
@@ -16,7 +16,14 @@
 
 // Base class for all load/store instruction stream
 
-class riscv_load_store_base_instr_stream extends riscv_directed_instr_stream;
+class riscv_load_store_base_instr_stream extends riscv_mem_access_stream;
+
+  typedef enum bit [1:0] {
+    NARROW,
+    HIGH,
+    MEDIUM,
+    SPARSE
+  } locality_e;
 
   rand int unsigned  num_load_store;
   rand int unsigned  num_mixed_instr;
@@ -25,6 +32,8 @@ class riscv_load_store_base_instr_stream extends riscv_directed_instr_stream;
   rand int           addr[];
   rand int unsigned  data_page_id;
   rand riscv_reg_t   rs1_reg;
+  rand locality_e    locality;
+  rand int           max_load_store_offset;
 
   `uvm_object_utils(riscv_load_store_base_instr_stream)
 
@@ -38,13 +47,35 @@ class riscv_load_store_base_instr_stream extends riscv_directed_instr_stream;
   }
 
   constraint addr_c {
+    solve data_page_id before max_load_store_offset;
+    solve max_load_store_offset before base;
+    solve max_load_store_offset before addr;
+    solve max_load_store_offset before offset;
     data_page_id < max_data_page_id;
+    foreach (data_page[i]) {
+      if (i == data_page_id) {
+        max_load_store_offset == data_page[i].size_in_bytes;
+      }
+    }
     base inside {[0 : max_load_store_offset-1]};
     foreach(offset[i]) {
       addr[i] == base + offset[i];
-      // Make sure address is still valid
       addr[i] inside {[0 : max_load_store_offset - 1]};
-      offset[i] inside {[-2048:2047]};
+    }
+  }
+
+  constraint offset_locality_c {
+    solve locality before offset;
+    foreach(offset[i]) {
+      if (locality == NARROW) {
+        soft offset[i] inside {[-16:16]};
+      } else if (locality == HIGH) {
+        soft offset[i] inside {[-64:64]};
+      } else if (locality == MEDIUM) {
+        soft offset[i] inside {[-256:256]};
+      } else if (locality == SPARSE) {
+        soft offset[i] inside {[-2048:2047]};
+      }
     }
   }
 
@@ -72,10 +103,10 @@ class riscv_load_store_base_instr_stream extends riscv_directed_instr_stream;
                                    pseudo_instr_name == LA;
                                    rd == rs1_reg;,
                                    "Cannot randomize la_instr")
-    if(access_u_mode_mem) begin
-      la_instr.imm_str = $sformatf("data_page_%0d+%0d", data_page_id, base);
+    if(kernel_mode) begin
+      la_instr.imm_str = $sformatf("%s+%0d", cfg.s_mem_region[data_page_id].name, base);
     end else begin
-      la_instr.imm_str = $sformatf("kernel_data_page_%0d+%0d", data_page_id, base);
+      la_instr.imm_str = $sformatf("%s+%0d", cfg.mem_region[data_page_id].name, base);
     end
     instr_list.push_front(la_instr);
   endfunction
@@ -253,27 +284,11 @@ class riscv_load_store_hazard_instr_stream extends riscv_load_store_base_instr_s
       addr[i] = temp_addr;
     end
   endfunction
-
-endclass
-
-// Back-to-back access to the same cache line
-class riscv_cache_line_stress_instr_stream extends riscv_load_store_stress_instr_stream;
-
-  constraint same_cache_line_c {
-    base % riscv_instr_pkg::dcache_line_size_in_bytes == 0;
-    foreach(offset[i]) {
-      offset[i] inside {[0 : riscv_instr_pkg::dcache_line_size_in_bytes-1]};
-    }
-  }
-
-  `uvm_object_utils(riscv_cache_line_stress_instr_stream)
-  `uvm_object_new
-
 endclass
 
 // Back to back access to multiple data pages
 // This is useful to test data TLB switch and replacement
-class riscv_multi_page_load_store_instr_stream extends riscv_directed_instr_stream;
+class riscv_multi_page_load_store_instr_stream extends riscv_mem_access_stream;
 
   riscv_load_store_stress_instr_stream load_store_instr_stream[];
   rand int unsigned num_of_instr_stream;
@@ -287,11 +302,15 @@ class riscv_multi_page_load_store_instr_stream extends riscv_directed_instr_stre
     data_page_id.size() == num_of_instr_stream;
     rs1_reg.size() == num_of_instr_stream;
     unique {rs1_reg};
-    unique {data_page_id};
-    num_of_instr_stream inside {[1 : max_data_page_id]};
     foreach(rs1_reg[i]) {
       !(rs1_reg[i] inside {cfg.reserved_regs, ZERO});
     }
+  }
+
+  constraint page_c {
+    solve num_of_instr_stream before data_page_id;
+    num_of_instr_stream inside {[1 : max_data_page_id]};
+    unique {data_page_id};
   }
 
   // Avoid accessing a large number of pages because we may run out of registers for rs1
@@ -332,5 +351,22 @@ class riscv_multi_page_load_store_instr_stream extends riscv_directed_instr_stre
       end
     end
   endfunction
+
+endclass
+
+// Access the different locations of the same memory regions
+class riscv_mem_region_stress_test extends riscv_multi_page_load_store_instr_stream;
+
+  `uvm_object_utils(riscv_mem_region_stress_test)
+  `uvm_object_new
+
+  constraint page_c {
+    num_of_instr_stream inside {[2:8]};
+    foreach (data_page_id[i]) {
+      if (i > 0) {
+        data_page_id[i] == data_page_id[i-1];
+      }
+    }
+  }
 
 endclass

--- a/src/riscv_page_table.sv
+++ b/src/riscv_page_table.sv
@@ -51,7 +51,6 @@ class riscv_page_table#(satp_mode_t MODE = SV39) extends uvm_object;
     // Align the page table to 4K boundary
     instr = {instr,
              ".align 12",
-             ".data",
              $sformatf("%0s:", get_name())};
     foreach(pte_binary[i]) begin
       if (i % 8 == 0) begin

--- a/test/riscv_instr_test_lib.sv
+++ b/test/riscv_instr_test_lib.sv
@@ -35,8 +35,8 @@ class riscv_rand_instr_test extends riscv_instr_base_test;
     asm_gen.add_directed_instr_stream("riscv_loop_instr", 4);
     asm_gen.add_directed_instr_stream("riscv_hazard_instr_stream", 4);
     asm_gen.add_directed_instr_stream("riscv_load_store_hazard_instr_stream", 4);
-    asm_gen.add_directed_instr_stream("riscv_cache_line_stress_instr_stream", 4);
     asm_gen.add_directed_instr_stream("riscv_multi_page_load_store_instr_stream", 4);
+    asm_gen.add_directed_instr_stream("riscv_mem_region_stress_test", 4);
   endfunction
 
 endclass

--- a/yaml/testlist.yaml
+++ b/yaml/testlist.yaml
@@ -76,8 +76,8 @@
     +directed_instr_1=riscv_loop_instr,4
     +directed_instr_2=riscv_hazard_instr_stream,4
     +directed_instr_3=riscv_load_store_hazard_instr_stream,4
-    +directed_instr_4=riscv_cache_line_stress_instr_stream,4
-    +directed_instr_5=riscv_multi_page_load_store_instr_stream,4
+    +directed_instr_4=riscv_multi_page_load_store_instr_stream,4
+    +directed_instr_5=riscv_mem_region_stress_test,4
   rtl_test: core_base_test
 
 # TODO: Temporarily disable this as compiler seems to generate compressed instruction with rv64im
@@ -114,8 +114,8 @@
     +num_of_sub_program=5
     +directed_instr_0=riscv_load_store_rand_instr_stream,40
     +directed_instr_1=riscv_load_store_hazard_instr_stream,40
-    +directed_instr_2=riscv_cache_line_stress_instr_stream,40
-    +directed_instr_3=riscv_multi_page_load_store_instr_stream,40
+    +directed_instr_2=riscv_multi_page_load_store_instr_stream,10
+    +directed_instr_3=riscv_mem_region_stress_test,10
   rtl_test: core_base_test
 
 # TODO: Re-enable this test after all the data/instruction page organization changes are done
@@ -229,8 +229,8 @@
     +num_of_sub_program=5
     +directed_instr_0=riscv_load_store_rand_instr_stream,20
     +directed_instr_1=riscv_load_store_hazard_instr_stream,20
-    +directed_instr_2=riscv_cache_line_stress_instr_stream,20
-    +directed_instr_3=riscv_multi_page_load_store_instr_stream,20
+    +directed_instr_2=riscv_multi_page_load_store_instr_stream,5
+    +directed_instr_3=riscv_mem_region_stress_test,5
     +enable_unaligned_load_store=1
   rtl_test: core_ibex_base_test
 


### PR DESCRIPTION
- Allow user to specify the range of each memory region
- Assign a separate section for each memory region so that it can be linked to match system memory map.
- Refactor load/store/amo test

update #129 