### PR TITLE
Interrupt test integration

### DIFF
--- a/scripts/gen_csr_test.py
+++ b/scripts/gen_csr_test.py
@@ -279,7 +279,7 @@ def gen_csr_instr(original_csr_map, csr_instructions, xlen,
     csr_map = copy.deepcopy(original_csr_map)
     source_reg, dest_reg = [f"x{i}" for i in random.sample(range(1, 16), 2)]
     csr_list = list(csr_map.keys())
-    with open(f"{out}/riscv_csr_test.{i}.S", "w") as csr_test_file:
+    with open(f"{out}/riscv_csr_test_{i}.S", "w") as csr_test_file:
       gen_setup(csr_test_file)
       for csr in csr_list:
         csr_address, csr_val, csr_write_mask, csr_read_mask = csr_map.get(csr)

--- a/setting/riscv_core_setting.sv
+++ b/setting/riscv_core_setting.sv
@@ -35,6 +35,10 @@ riscv_instr_group_t supported_isa[$] = {RV32I, RV32M, RV64I, RV64M, RV32C, RV64C
 // Interrupt mode support
 mtvec_mode_t supported_interrupt_mode[$] = {DIRECT, VECTORED};
 
+// The number of interrupt vectors to be generated, only used if VECTORED interrupt mode is
+// supported
+int max_interrupt_vector_num = 16;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/src/riscv_instr_gen_config.sv
+++ b/src/riscv_instr_gen_config.sv
@@ -49,6 +49,10 @@ class riscv_instr_gen_config extends uvm_object;
   // Priviledged mode after boot
   rand privileged_mode_t init_privileged_mode;
 
+  rand bit[XLEN-1:0] mstatus, mie,
+                     sstatus, sie,
+                     ustatus, uie;
+
   // Key fields in xSTATUS
   // Memory protection bits
   rand bit               mstatus_mprv;

--- a/src/riscv_instr_pkg.sv
+++ b/src/riscv_instr_pkg.sv
@@ -598,7 +598,6 @@ package riscv_instr_pkg;
   } privileged_level_t;
 
   typedef enum bit [1:0] {
-    WIRI, // Reserved Writes Ignored, Reads Ignore Value
     WPRI, // Reserved Writes Preserve Values, Reads Ignore Value
     WLRL, // Write/Read Only Legal Values
     WARL  // Write Any Values, Reads Legal Values

--- a/src/riscv_privil_reg.sv
+++ b/src/riscv_privil_reg.sv
@@ -31,29 +31,29 @@ class riscv_privil_reg extends riscv_reg#(privileged_reg_t);
       MISA: begin
         privil_level = M_LEVEL;
         add_field("WARL0", 26, WARL);
-        add_field("WIRI", XLEN-28, WIRI);
+        add_field("WLRL", XLEN-28, WLRL);
         add_field("MXL", 2, WARL);
       end
       // Machine Vendor ID Register
       MVENDORID: begin
         privil_level = M_LEVEL;
-        add_field("OFFSET", 7, WIRI);
-        add_field("BANK", XLEN-7, WIRI);
+        add_field("OFFSET", 7, WPRI);
+        add_field("BANK", XLEN-7, WPRI);
       end
       // Machine Architecture ID Register
       MARCHID: begin
         privil_level = M_LEVEL;
-        add_field("ARCHITECTURE_ID", XLEN, WIRI);
+        add_field("ARCHITECTURE_ID", XLEN, WPRI);
       end
       // Machine Implementation ID Register
       MIMPID: begin
         privil_level = M_LEVEL;
-        add_field("IMPLEMENTATION", XLEN, WIRI);
+        add_field("IMPLEMENTATION", XLEN, WPRI);
       end
       // Hart ID Register
       MHARTID: begin
         privil_level = M_LEVEL;
-        add_field("HART_ID", XLEN, WIRI);
+        add_field("HART_ID", XLEN, WPRI);
       end
       // Machine Status Register
       MSTATUS: begin
@@ -136,7 +136,7 @@ class riscv_privil_reg extends riscv_reg#(privileged_reg_t);
         privil_level = M_LEVEL;
         add_field("USIP",   1,  WARL);
         add_field("SSIP",   1,  WARL);
-        add_field("WIRI0",  1,  WIRI);
+        add_field("WPRI0",  1,  WPRI);
         add_field("MSIP",   1,  WARL);
         add_field("UTIP",   1,  WARL);
         add_field("STIP",   1,  WARL);
@@ -144,9 +144,9 @@ class riscv_privil_reg extends riscv_reg#(privileged_reg_t);
         add_field("MTIP",   1,  WARL);
         add_field("UEIP",   1,  WARL);
         add_field("SEIP",   1,  WARL);
-        add_field("WIRI2",  1,  WIRI);
+        add_field("WPRI2",  1,  WPRI);
         add_field("MEIP",   1,  WARL);
-        add_field("WIRI3",  XLEN - 12,  WIRI);
+        add_field("WPRI3",  XLEN - 12,  WPRI);
       end
       // Machine interrupt-enable register
       MIE: begin
@@ -168,27 +168,27 @@ class riscv_privil_reg extends riscv_reg#(privileged_reg_t);
       // Cycle Count Register
       MCYCLE: begin
         privil_level = M_LEVEL;
-        add_field("MCYCLE", 64, WIRI);
+        add_field("MCYCLE", 64, WPRI);
       end
       // Instruction Count Register
       MINSTRET: begin
         privil_level = M_LEVEL;
-        add_field("MINSTRET", 64, WIRI);
+        add_field("MINSTRET", 64, WPRI);
       end
       // Cycle Count Register - RV32I only
       MCYCLEH: begin
         privil_level = M_LEVEL;
-        add_field("MCYCLEH", 32, WIRI);
+        add_field("MCYCLEH", 32, WPRI);
       end
       // Instruction Count Register - RV32I only
       MINSTRETH: begin
         privil_level = M_LEVEL;
-        add_field("MINSTRETH", 32, WIRI);
+        add_field("MINSTRETH", 32, WPRI);
       end
       // Hardware Performance Monitor Counters
       [MHPMCOUNTER3:MHPMCOUNTER31]: begin
         privil_level = M_LEVEL;
-        add_field($sformatf("%s", reg_name.name()), XLEN, WIRI);
+        add_field($sformatf("%s", reg_name.name()), XLEN, WARL);
       end
       // Hardware Performance Monitor Events
       [MHPMEVENT3:MHPMEVENT31]: begin
@@ -201,7 +201,7 @@ class riscv_privil_reg extends riscv_reg#(privileged_reg_t);
           `uvm_fatal(get_full_name(), $sformatf("Register %s is only in RV32I", reg_name.name()))
         end
         privil_level = M_LEVEL;
-        add_field($sformatf("%s", reg_name.name()), 32, WIRI);
+        add_field($sformatf("%s", reg_name.name()), 32, WARL);
       end
       // Machine Counter Enable Register
       MCOUNTEREN: begin
@@ -324,7 +324,7 @@ class riscv_privil_reg extends riscv_reg#(privileged_reg_t);
         privil_level = M_LEVEL;
         if(XLEN==64) begin
           add_field("ADDRESS", 54, WARL);
-          add_field("WIRI", 10, WIRI);
+          add_field("WARL", 10, WARL);
         end else begin
           add_field("ADDRESS", 32, WARL);
         end
@@ -560,16 +560,6 @@ class riscv_privil_reg extends riscv_reg#(privileged_reg_t);
       default:
         `uvm_fatal(get_full_name(), $sformatf("reg %0s is not supported yet", reg_name.name()))
     endcase
-    set_wiri_wpri_fields();
-  endfunction
-
-  // Hardwire all WIRI and WPRI fields to '0
-  virtual function void set_wiri_wpri_fields();
-    foreach(fld[i]) begin
-      if(fld[i].access_type inside {WIRI, WPRI}) begin
-        set_field(fld[i].get_name(), '0, 1'b1);
-      end
-    end
   endfunction
 
 endclass

--- a/src/riscv_reg.sv
+++ b/src/riscv_reg.sv
@@ -153,7 +153,4 @@ class riscv_reg#(type REG_T = privileged_reg_t) extends uvm_object;
     end
   endfunction
 
-  virtual function void set_wiri_wpri_fields();
-  endfunction
-
 endclass

--- a/src/riscv_signature_pkg.sv
+++ b/src/riscv_signature_pkg.sv
@@ -42,6 +42,7 @@ package riscv_signature_pkg;
     IN_SUPERVISOR_MODE,
     IN_USER_MODE,
     HANDLING_IRQ,
+    FINISHED_IRQ,
     HANDLING_EXCEPTION,
     ILLEGAL_INSTR_EXCEPTION,
     EBREAK_EXCEPTION
@@ -51,6 +52,5 @@ package riscv_signature_pkg;
     TEST_PASS,
     TEST_FAIL
   } test_result_t;
-
 
 endpackage


### PR DESCRIPTION
-Add handshakes to write xIE, xIP, and xCAUSE to the testbench on exceptions and interrupts for more checking analysis
- Removed all csr WIRI fields as per the spec
- make WPRI csr fields writable, to allow for platform-specific csr configurations
- randomize csr generation, in particular the interrupt enable bits in xSTATUS and xIE