### PR TITLE
Fix spike arguments to generate commit log

### DIFF
--- a/yaml/iss.yaml
+++ b/yaml/iss.yaml
@@ -15,7 +15,7 @@
 - iss: spike
   path_var: SPIKE_PATH
   cmd: >
-    <path_var>/spike --isa=<variant> -l <elf>
+    <path_var>/spike --log-commits --isa=<variant> -l <elf>
 
 - iss: ovpsim
   path_var: OVPSIM_PATH


### PR DESCRIPTION
Spike now needs the --log-commits option passed to it to generate commit
info in the log.