### PR TITLE
Add more ebreak generation control

### DIFF
--- a/src/riscv_instr_gen_config.sv
+++ b/src/riscv_instr_gen_config.sv
@@ -560,13 +560,11 @@ class riscv_instr_gen_config extends uvm_object;
   virtual function void build_instruction_list();
     basic_instr = {instr_category[SHIFT], instr_category[ARITHMETIC],
                    instr_category[LOGICAL], instr_category[COMPARE]};
-    if (no_ebreak == 0) begin
-      basic_instr = {basic_instr, EBREAK};
-      foreach(riscv_instr_pkg::supported_isa[i]) begin
-        if (riscv_instr_pkg::supported_isa[i] inside {RV32C, RV64C, RV128C, RV32DC, RV32FC}) begin
-          basic_instr = {basic_instr, C_EBREAK};
-          break;
-        end
+    basic_instr = {basic_instr, EBREAK};
+    foreach(riscv_instr_pkg::supported_isa[i]) begin
+      if (riscv_instr_pkg::supported_isa[i] inside {RV32C, RV64C, RV128C, RV32DC, RV32FC}) begin
+        basic_instr = {basic_instr, C_EBREAK};
+        break;
       end
     end
     if (no_dret == 0) begin

--- a/src/riscv_instr_stream.sv
+++ b/src/riscv_instr_stream.sv
@@ -203,7 +203,7 @@ class riscv_rand_instr_stream extends riscv_instr_stream;
     riscv_instr_name_t instr_name;
     // if set_dcsr_ebreak is set, we do not want to generate any ebreak
     // instructions inside the debug_rom
-    if (!cfg.enable_ebreak_in_debug_rom && is_in_debug) begin
+    if ((cfg.no_ebreak && !is_in_debug) || (!cfg.enable_ebreak_in_debug_rom && is_in_debug)) begin
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(instr_name,
                                         instr_name inside {allowed_instr};
                                         !(instr_name inside {EBREAK, C_EBREAK});)


### PR DESCRIPTION
-Enable full configuration of ebreak generation - all permutations of ebreak in main program and debug program are now possible.
-For the debug_ebreak_test in particular, move the DCSR and DPC handshakes within the stack push/pop operations to avoid corrupting program state