### PR TITLE
Add directed stream to access higher privilege CSRs

### DIFF
--- a/src/riscv_asm_program_gen.sv
+++ b/src/riscv_asm_program_gen.sv
@@ -389,34 +389,36 @@ class riscv_asm_program_gen extends uvm_object;
   // repeated writes to these CSRs.
   virtual function void gen_dummy_csr_write();
     string instr[$];
-    case (cfg.init_privileged_mode)
-      MACHINE_MODE: begin
-        instr.push_back($sformatf("csrr x%0d, 0x%0x", cfg.gpr[0], MSTATUS));
-        instr.push_back($sformatf("csrr x%0d, 0x%0x", cfg.gpr[1], MIE));
-        instr.push_back($sformatf("csrw 0x%0x, x%0d", MSTATUS, cfg.gpr[0]));
-        instr.push_back($sformatf("csrw 0x%0x, x%0d", MIE, cfg.gpr[1]));
-      end
-      SUPERVISOR_MODE: begin
-        instr.push_back($sformatf("csrr x%0d, 0x%0x", cfg.gpr[0], SSTATUS));
-        instr.push_back($sformatf("csrr x%0d, 0x%0x", cfg.gpr[1], SIE));
-        instr.push_back($sformatf("csrw 0x%0x, x%0d", SSTATUS, cfg.gpr[0]));
-        instr.push_back($sformatf("csrw 0x%0x, x%0d", SIE, cfg.gpr[1]));
-      end
-      USER_MODE: begin
-        if (!riscv_instr_pkg::support_umode_trap) begin
-          return;
+    if (cfg.enable_dummy_csr_write) begin
+      case (cfg.init_privileged_mode)
+        MACHINE_MODE: begin
+          instr.push_back($sformatf("csrr x%0d, 0x%0x", cfg.gpr[0], MSTATUS));
+          instr.push_back($sformatf("csrr x%0d, 0x%0x", cfg.gpr[1], MIE));
+          instr.push_back($sformatf("csrw 0x%0x, x%0d", MSTATUS, cfg.gpr[0]));
+          instr.push_back($sformatf("csrw 0x%0x, x%0d", MIE, cfg.gpr[1]));
         end
-        instr.push_back($sformatf("csrr x%0d, 0x%0x", cfg.gpr[0], USTATUS));
-        instr.push_back($sformatf("csrr x%0d, 0x%0x", cfg.gpr[1], UIE));
-        instr.push_back($sformatf("csrw 0x%0x, x%0d", USTATUS, cfg.gpr[0]));
-        instr.push_back($sformatf("csrw 0x%0x, x%0d", UIE, cfg.gpr[1]));
-      end
-      default: begin
-        `uvm_fatal(`gfn, "Unsupported boot mode")
-      end
-    endcase
-    format_section(instr);
-    instr_stream = {instr_stream, instr};
+        SUPERVISOR_MODE: begin
+          instr.push_back($sformatf("csrr x%0d, 0x%0x", cfg.gpr[0], SSTATUS));
+          instr.push_back($sformatf("csrr x%0d, 0x%0x", cfg.gpr[1], SIE));
+          instr.push_back($sformatf("csrw 0x%0x, x%0d", SSTATUS, cfg.gpr[0]));
+          instr.push_back($sformatf("csrw 0x%0x, x%0d", SIE, cfg.gpr[1]));
+        end
+        USER_MODE: begin
+          if (!riscv_instr_pkg::support_umode_trap) begin
+            return;
+          end
+          instr.push_back($sformatf("csrr x%0d, 0x%0x", cfg.gpr[0], USTATUS));
+          instr.push_back($sformatf("csrr x%0d, 0x%0x", cfg.gpr[1], UIE));
+          instr.push_back($sformatf("csrw 0x%0x, x%0d", USTATUS, cfg.gpr[0]));
+          instr.push_back($sformatf("csrw 0x%0x, x%0d", UIE, cfg.gpr[1]));
+        end
+        default: begin
+          `uvm_fatal(`gfn, "Unsupported boot mode")
+        end
+      endcase
+      format_section(instr);
+      instr_stream = {instr_stream, instr};
+    end
   endfunction
 
   // Initialize general purpose registers with random value

--- a/src/riscv_instr_base.sv
+++ b/src/riscv_instr_base.sv
@@ -610,11 +610,15 @@ class riscv_instr_base extends uvm_object;
   endfunction
 
   function void gen_rand_csr(bit illegal_csr_instr = 0,
+                             bit legal_invalid_csr_instr = 0,
+                             privileged_reg_t invalid_csrs[$] = {},
                              bit enable_floating_point = 0,
                              privileged_mode_t privileged_mode = MACHINE_MODE);
     privileged_reg_t preg[$];
     if (illegal_csr_instr) begin
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(csr, !(csr inside {implemented_csr});)
+    end else if (legal_invalid_csr_instr) begin
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(csr, csr inside {invalid_csrs};)
     end else begin
       // Use scratch register to avoid the side effect of modifying other privileged mode CSR.
       if (privileged_mode == MACHINE_MODE)

--- a/src/riscv_instr_stream.sv
+++ b/src/riscv_instr_stream.sv
@@ -285,7 +285,9 @@ class riscv_rand_instr_stream extends riscv_instr_stream;
     if ((instr.category == CSR) && !skip_csr) begin
       instr.gen_rand_csr(.privileged_mode(cfg.init_privileged_mode),
                          .enable_floating_point(cfg.enable_floating_point),
-                         .illegal_csr_instr(cfg.enable_illegal_csr_instruction));
+                         .illegal_csr_instr(cfg.enable_illegal_csr_instruction),
+                         .legal_invalid_csr_instr(cfg.enable_access_invalid_csr_level),
+                         .invalid_csrs(cfg.invalid_priv_mode_csrs));
     end
     if (instr.has_fs1) begin
       instr.fs1 = instr.gen_rand_fpr();

--- a/src/riscv_rand_instr.sv
+++ b/src/riscv_rand_instr.sv
@@ -95,19 +95,27 @@ class riscv_rand_instr extends riscv_instr_base;
 
   constraint csr_instr_c {
     // TODO: support CSR instruction in other modes
-    if(cfg.no_csr_instr || (cfg.init_privileged_mode != MACHINE_MODE)) {
+    if(cfg.no_csr_instr) {
       category != CSR;
     } else {
       if (cfg.enable_illegal_csr_instruction) {
         !(csr inside {implemented_csr});
+      } else if (cfg.enable_access_invalid_csr_level) {
+        csr inside {cfg.invalid_priv_mode_csrs};
       } else {
         // Use scratch register to avoid the side effect of modifying other privileged mode CSR.
         if (cfg.init_privileged_mode == MACHINE_MODE) {
-          csr == MSCRATCH;
+          if (MSCRATCH inside {implemented_csr}) {
+            csr == MSCRATCH;
+          }
         } else if (cfg.init_privileged_mode == SUPERVISOR_MODE) {
-          csr == SSCRATCH;
+          if (SSCRATCH inside {implemented_csr}) {
+            csr == SSCRATCH;
+          }
         } else {
-          csr == USCRATCH;
+          if (USCRATCH inside {implemented_csr}) {
+            csr == USCRATCH;
+          }
         }
       }
     }

--- a/target/rv64gc/testlist.yaml
+++ b/target/rv64gc/testlist.yaml
@@ -53,6 +53,21 @@
     +num_of_sub_program=5
   rtl_test: core_base_test
 
+# TODO: Only enable booting into U-mode for now, as OVPsim doesn't support some debug CSRs
+- test: riscv_invalid_csr_test
+  description: >
+    Boot core into random privileged mode and generate csr accesses to invalid CSRs (at a higher priv mode)
+  iterations: 2
+  gen_test: riscv_rand_instr_test
+  gen_opts: >
+    +require_signature_addr=1
+    +instr_cnt=6000
+    +num_of_sub_program=0
+    +enable_access_invalid_csr_level=1
+    +boot_mode=u
+  rtl_test: core_invalid_csr_test
+  sim_opts: >
+    +require_signature_addr=1
 
 # TODO: Re-enable this test after all the data/instruction page organization changes are done
 - test: riscv_page_table_exception_test

--- a/yaml/base_testlist.yaml
+++ b/yaml/base_testlist.yaml
@@ -151,6 +151,7 @@
   gen_opts: >
     +instr_cnt=6000
     +no_ebreak=0
+    +require_signature_addr=1
   rtl_test: core_base_test
   sim_opts: >
     +require_signature_addr=1
@@ -165,9 +166,11 @@
   gen_test: riscv_rand_instr_test
   gen_opts: >
     +enable_interrupt=1
+    +require_signature_addr=1
   rtl_test: core_base_test
   sim_opts: >
     +enable_irq_seq=1
+    +require_signature_addr=1
   compare_opts: >
     +compare_final_value_only=1
 


### PR DESCRIPTION
- All invalid (e.g. higher privilege level) CSRs are added to a queue in `cfg` on generator initialization, making constraints much more simplified