### PR TITLE
Adding support qrun simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ work/
 /.project
 /outdir/
 ucli.key
+qrun.out/
+qrun.log

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ python3 run.py --test riscv_arithmetic_basic_test --simulator ius
 python3 run.py --test riscv_arithmetic_basic_test --simulator vcs
 python3 run.py --test riscv_arithmetic_basic_test --simulator questa
 python3 run.py --test riscv_arithmetic_basic_test --simulator dsim
+python3 run.py --test riscv_arithmetic_basic_test --simulator qrun
 ```
 The complete test list can be found in [yaml/testlist.yaml](https://github.com/google/riscv-dv/blob/master/yaml/testlist.yaml). To run a full
 regression, simply use below command

--- a/qrun_option.f
+++ b/qrun_option.f
@@ -1,0 +1,10 @@
+-64
+-uvmhome uvm-1.2
+-sv
+-mfcu
+-cuname design_cuname
++define+UVM_REGEX_NO_DPI
+-debug
++designfile
+-o design_opt
+-optimize

--- a/yaml/simulator.yaml
+++ b/yaml/simulator.yaml
@@ -86,3 +86,18 @@
     cmd: >
       <DSIM> <sim_opts> -sv_seed <seed> -pli_lib <DSIM_LIB_PATH>/libuvm_dpi.so +acc+rwb -image image -work <out>/dsim
 
+- tool: qrun
+  compile:
+    cmd:
+      - "qrun -f <cwd>/qrun_option.f
+        +incdir+<setting>
+        +incdir+<user_extension>
+        -f <cwd>/files.f
+        -vlog.l <out>/compile.log <cmp_opts>
+        -vopt.l <out>/optimize.log
+        -outdir <out>/qrun.out"
+  sim:
+    cmd: >
+      qrun -64 -simulate -snapshot design_opt -c <cov_opts> <sim_opts> -sv_seed <seed>
+    cov_opts: >
+      -do "coverage save -onexit <out>/cov.ucdb;"


### PR DESCRIPTION
Hi, Mentor released a new feature named `qrun`. The qrun simplifies the use of QuestaSIM by automatically combining the compile, optimize, and simulate functions into a single step. The qrun command has these major features:
1. All tool arguments and source files go on the same qrun command line.
2. All vlog, vopt, vsim arguments go on the qrun command line unmodified.
3. It is able to support two or three step flows.
4. Provides pre-built flows for coverage, debug, UVM and other flows. No need to construct arguments for multiple tools.
5. If you re-invoke the same command with no source code or command line argument changes, then the qrun command skips compilation and optimization and invokes vsim.

You can read reference information of qrun at: https://docs.sw.siemens.com/en-US/product/852852103/doc/DC201909129.docs.questa_sim_qrun_user.en_us/html/idf05a7c8b-7e8f-45a9-ae9a-8c79a9adf0f5

I am happy to see qrun can support this project. So, I send the patch to make qrun work. Thank you

Sincerely,
Hai Hoang Dang