### PR TITLE
Fix CSR randomization bug when generating loops

### DIFF
--- a/src/riscv_loop_instr.sv
+++ b/src/riscv_loop_instr.sv
@@ -148,7 +148,15 @@ class riscv_loop_instr extends riscv_rand_instr_stream;
       loop_branch_target_instr[i].cfg = cfg;
       loop_branch_target_instr[i].reserved_rd = reserved_rd;
       `DV_CHECK_RANDOMIZE_WITH_FATAL(loop_branch_target_instr[i],
-                                     !(category inside {LOAD, STORE, BRANCH, JUMP});,
+                                     !(category inside {LOAD, STORE, BRANCH, JUMP});
+                                     // TODO: allow CSR instructions in all modes
+                                     if (cfg.init_privileged_mode == MACHINE_MODE) {
+                                       if (category == CSR) {
+                                         csr == MSCRATCH;
+                                       }
+                                     } else {
+                                       !(category == CSR);
+                                     },
                                      "Cannot randomize branch target instruction")
       loop_branch_target_instr[i].label = $sformatf("%0s_%0d_t", label, i);
 

--- a/src/riscv_rand_instr.sv
+++ b/src/riscv_rand_instr.sv
@@ -106,11 +106,17 @@ class riscv_rand_instr extends riscv_instr_base;
         } else {
           // Use scratch register to avoid the side effect of modifying other privileged mode CSR.
           if (cfg.init_privileged_mode == MACHINE_MODE) {
-            csr == MSCRATCH;
+            if (MSCRATCH inside {implemented_csr}) {
+              csr == MSCRATCH;
+            }
           } else if (cfg.init_privileged_mode == SUPERVISOR_MODE) {
-            csr == SSCRATCH;
+            if (SSCRATCH inside {implemented_csr}) {
+              csr == SSCRATCH;
+            }
           } else {
-            csr == USCRATCH;
+            if (USCRATCH inside {implemented_csr}) {
+              csr == USCRATCH;
+            }
           }
         }
       }


### PR DESCRIPTION
Fix bug introduced by #321 that would cause instructions acting as loop branch targets to access completely random CSRs