### PR TITLE
Fix list access exception thrown when parsing ovpsim illegal instruction

### DIFF
--- a/cov.py
+++ b/cov.py
@@ -94,7 +94,7 @@ def collect_cov(log_dir, out, core, iss, testlist, batch_size, lsf_cmd, steps, \
                 dont_truncate_after_first_ecall)
         else:
           logging.error("Full trace for %s is not supported yet" % iss)
-          sys.exit(1)
+          sys.exit(RET_FAIL)
   if steps == "all" or re.match("cov", steps):
     opts_vec = ""
     opts_cov = ""

--- a/run.py
+++ b/run.py
@@ -72,7 +72,7 @@ def get_generator_cmd(simulator, simulator_yaml, cov, exp):
           sim_cmd = re.sub("<"+env_var+">", get_env_var(env_var), sim_cmd)
       return compile_cmd, sim_cmd
   logging.error("Cannot find RTL simulator %0s" % simulator)
-  sys.exit(1)
+  sys.exit(RET_FAIL)
 
 
 def parse_iss_yaml(iss, iss_yaml, isa, setting_dir):
@@ -112,7 +112,7 @@ def parse_iss_yaml(iss, iss_yaml, isa, setting_dir):
         cmd = re.sub("\<variant\>", isa, cmd)
       return cmd
   logging.error("Cannot find ISS %0s" % iss)
-  sys.exit(1)
+  sys.exit(RET_FAIL)
 
 
 def get_iss_cmd(base_cmd, elf, log):
@@ -465,7 +465,7 @@ def iss_cmp(test_list, iss, output_dir, isa, stop_on_first_error):
           process_whisper_sim_log(log, csv)
         else:
           logging.error("Unsupported ISS" % iss)
-          sys.exit(1)
+          sys.exit(RET_FAIL)
       compare_trace_csv(csv_list[0], csv_list[1], iss_list[0], iss_list[1], report)
   passed_cnt = run_cmd("grep PASSED %s | wc -l" % report).strip()
   failed_cnt = run_cmd("grep FAILED %s | wc -l" % report).strip()

--- a/scripts/gen_csr_test.py
+++ b/scripts/gen_csr_test.py
@@ -32,12 +32,13 @@ import yaml
 import argparse
 import random
 import copy
+from lib import *
 
 try:
   from bitstring import BitArray as bitarray
 except ImportError as e:
   logging.error("Please install bitstring package: sudo apt-get install python3-bitstring")
-  sys.exit(1)
+  sys.exit(RET_FAIL)
 
 """
 Defines the test's success/failure values, one of which will be written to

--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -27,6 +27,10 @@ import logging
 
 from datetime import date
 
+RET_SUCCESS = 0
+RET_FAIL    = 1
+RET_FATAL   = -1
+
 def setup_logging(verbose):
   """Setup the root logger.
 
@@ -57,7 +61,7 @@ def read_yaml(yaml_file):
       yaml_data = yaml.safe_load(f)
     except yaml.YAMLError as exc:
       logging.error(exc)
-      sys.exit(1)
+      sys.exit(RET_FAIL)
   return yaml_data
 
 
@@ -74,7 +78,7 @@ def get_env_var(var):
     val = os.environ[var]
   except KeyError:
     logging.warning("Please set the environment variable %0s" % var)
-    sys.exit(1)
+    sys.exit(RET_FAIL)
   return val
 
 
@@ -112,7 +116,7 @@ def run_cmd(cmd, timeout_s = 999, exit_on_error = 1, check_return_code = True):
                           stderr=subprocess.STDOUT)
   except subprocess.CalledProcessError as exc:
     logging.error(ps.communicate()[0])
-    sys.exit(1)
+    sys.exit(RET_FAIL)
   try:
     output = ps.communicate(timeout = timeout_s)[0]
   except subprocess.TimeoutExpired:
@@ -124,7 +128,7 @@ def run_cmd(cmd, timeout_s = 999, exit_on_error = 1, check_return_code = True):
     logging.info(output)
     logging.error("ERROR return code: %d/%d, cmd:%s" % (check_return_code, rc, cmd))
     if exit_on_error:
-      sys.exit(1)
+      sys.exit(RET_FAIL)
   logging.debug(output)
   return output
 
@@ -160,7 +164,7 @@ def run_parallel_cmd(cmd_list, timeout_s = 999, exit_on_error = 0, check_return_
       logging.info(output)
       logging.error("ERROR return code: %d, cmd:%s" % (rc, cmd))
       if exit_on_error:
-        sys.exit(1)
+        sys.exit(RET_FAIL)
     # Restore stty setting otherwise the terminal may go crazy
     os.system("stty sane")
     logging.debug(output)

--- a/scripts/riscv_trace_csv.py
+++ b/scripts/riscv_trace_csv.py
@@ -20,6 +20,7 @@ import csv
 import re
 import logging
 import sys
+from lib import *
 
 class RiscvInstructionTraceEntry(object):
   """RISC-V instruction trace entry"""
@@ -510,4 +511,4 @@ def assign_operand(trace, operands, gpr, stop_on_first_error = 0):
     logging.debug("Unsupported instr : %s (%s)" %
                   (trace.instr, trace.instr_str))
     if stop_on_first_error:
-        sys.exit(-1)
+        sys.exit(RET_FATAL)


### PR DESCRIPTION
also make ovpsim parsing script indentations 2 spaces, to avoid mixing 2-space and 4-space indents in one file