### PR TITLE
Cleaning the output directory by default. Using "--noclean" for using the output of previous runs

### DIFF
--- a/cov.py
+++ b/cov.py
@@ -106,10 +106,10 @@ def collect_cov(log_dir, out, core, iss, testlist, batch_size, lsf_cmd, steps, \
     if compliance_mode:
       opts_cov += " +define+COMPLIANCE_MODE"
     build_cmd = ("python3 %s/run.py --simulator %s --simulator_yaml %s "
-                 " --co -o %s --cov -tl %s %s --cmp_opts \"%s %s\" " %
+                 " --co -o %s --cov -tl %s %s --cmp_opts \"%s %s\" --noclean" %
                  (cwd, simulator, simulator_yaml, out, testlist, opts,
                     opts_vec, opts_cov))
-    base_sim_cmd = ("python3 %s/run.py --simulator %s --simulator_yaml %s "
+    base_sim_cmd = ("python3 %s/run.py --simulator %s --simulator_yaml %s --noclean "
                     "--so -o %s --cov -tl %s %s "
                     "-tn riscv_instr_cov_test --steps gen --sim_opts \"<trace_csv_opts> %s %s\" " %
                     (cwd, simulator, simulator_yaml, out, testlist, opts,
@@ -178,10 +178,10 @@ def run_cov_debug_test(out, instr_cnt, testlist, batch_size, opts, lsf_cmd,\
   sim_cmd_list = []
   logging.info("Building the coverage collection framework")
   build_cmd = ("python3 %s/run.py --simulator %s --simulator_yaml %s "
-               "--co -o %s --cov -tl %s %s" %
+               "--co -o %s --cov -tl %s %s --noclean" %
                (cwd, simulator, simulator_yaml, out, testlist, opts))
   base_sim_cmd = ("python3 %s/run.py --simulator %s --simulator_yaml %s "
-                  "--so -o %s --cov -tl %s --isa %s %s "
+                  "--so -o %s --cov -tl %s --isa %s %s --noclean "
                   "-tn riscv_instr_cov_debug_test --steps gen "
                   "--sim_opts \"+num_of_iterations=<instr_cnt>\"" %
                   (cwd, simulator, simulator_yaml, out, testlist, isa, opts))
@@ -271,7 +271,7 @@ def setup_parser():
                       action="store_true", help="Stop on detecting first error")
   parser.add_argument("--dont_truncate_after_first_ecall", dest="dont_truncate_after_first_ecall",
                       action="store_true", help="Do not truncate log and csv file on first ecall")
-  parser.add_argument("--noclean", action="store_true",
+  parser.add_argument("--noclean", action="store_true", default=False,
                       help="Do not clean the output of the previous runs")
   parser.add_argument("--vector_options", type=str, default="",
                       help="Enable Vectors and set options")
@@ -321,13 +321,7 @@ def main():
   args.testlist = cwd + "/yaml/cov_testlist.yaml" ## needed if need to force
 
   # Create output directory
-  output_dir = create_output(args.o, "cov_out_")
-
-  if args.noclean is False:
-    os.system("rm -rf %s" % output_dir)
-
-  logging.info("Creating output directory: %s" % output_dir)
-  subprocess.run(["mkdir", "-p", output_dir])
+  output_dir = create_output(args.o, args.noclean, "cov_out_")
 
   if args.debug_mode:
     run_cov_debug_test(output_dir, args.instr_cnt, args.testlist,

--- a/run.py
+++ b/run.py
@@ -585,6 +585,8 @@ def setup_parser():
                            " job to small batches with this option")
   parser.add_argument("--stop_on_first_error", dest="stop_on_first_error", action="store_true",
                       help="Stop on detecting first error")
+  parser.add_argument("--noclean", action="store_true", default=False,
+                      help="Do not clean the output of the previous runs")
   parser.set_defaults(co=False)
   parser.set_defaults(so=False)
   parser.set_defaults(verbose=False)
@@ -651,9 +653,7 @@ def main():
       args.testlist = args.custom_target + "/testlist.yaml"
 
   # Create output directory
-  output_dir = create_output(args.o)
-  logging.info("Creating output directory: %s" % output_dir)
-  subprocess.run(["mkdir", "-p", output_dir])
+  output_dir = create_output(args.o, args.noclean)
   subprocess.run(["mkdir", "-p", ("%s/asm_tests" % output_dir)])
 
   if args.asm_test != "":

--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -197,16 +197,22 @@ def process_regression_list(testlist, test, iterations, matched_list, riscv_dv_r
                       (entry['test'], entry['iterations']))
           matched_list.append(entry)
 
-def create_output(output, prefix = "out_"):
+def create_output(output, noclean, prefix = "out_"):
   """ Create output directory
 
   Args:
     output : Name of specified output directory
+    noclean: Do not clean the output of the previous runs
 
   Returns:
     Output directory
   """
   # Create output directory
   if output is None:
-    return prefix + str(date.today())
+    output = prefix + str(date.today())
+  if noclean is False:
+    os.system("rm -rf %s" % output)
+
+  logging.info("Creating output directory: %s" % output)
+  subprocess.run(["mkdir", "-p", output])
   return output


### PR DESCRIPTION
I make PR to clean the output directory by default.
Do not clean the output directory may have effect on expected output because of the output of previous run. Similarly for cov.py, if people want to use the output of previous runs, it can be specified by "--noclean" switch.