### PR TITLE
Fix running cov without arguments

### DIFF
--- a/cov.py
+++ b/cov.py
@@ -123,6 +123,9 @@ def collect_cov(out, cfg, cwd):
   argv= SimpleNamespace(**cfg)
   log_list = []
   csv_list = []
+  if not argv.dir:
+    logging.error("Missing directory of trace log files")
+    sys.exit(RET_FAIL)
   logging.info("Processing trace log under %s" % argv.dir)
   if not os.path.isdir(argv.dir) or not os.listdir(argv.dir):
     logging.error("Cannot find %s directory, or it is empty", argv.dir)


### PR DESCRIPTION
Running: $ cov
Tue, 07 Jan 2020 10:47:27 INFO     Creating output directory: cov_out_2020-01-07
Tue, 07 Jan 2020 10:47:27 INFO     Processing trace log under None
Traceback (most recent call last):
  File "/home/danghai/.local/bin/cov", line 11, in <module>
    load_entry_point('riscv-dv', 'console_scripts', 'cov')()
  File "/home/danghai/hhoangda/riscv-dv/cov.py", line 289, in main
    collect_cov(output_dir, cfg ,cwd)
  File "/home/danghai/hhoangda/riscv-dv/cov.py", line 127, in collect_cov
    if not os.path.isdir(argv.dir) or not os.listdir(argv.dir):
  File "/usr/lib/python3.6/genericpath.py", line 42, in isdir
    st = os.stat(s)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType