### PR TITLE
Implement storing the commands that would be executed as a script

### DIFF
--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -96,7 +96,7 @@ def get_seed(seed):
   return random.getrandbits(32)
 
 
-def run_cmd(cmd, timeout_s = 999, exit_on_error = 1, check_return_code = True):
+def run_cmd(cmd, debug_cmd = None, timeout_s = 999, exit_on_error = 1, check_return_code = True):
   """Run a command and return output
 
   Args:
@@ -106,6 +106,10 @@ def run_cmd(cmd, timeout_s = 999, exit_on_error = 1, check_return_code = True):
     command output
   """
   logging.debug(cmd)
+  if debug_cmd:
+    debug_cmd.write(cmd)
+    debug_cmd.write("\n\n");
+    return
   try:
     ps = subprocess.Popen("exec " + cmd,
                           shell=True,
@@ -174,12 +178,16 @@ def run_parallel_cmd(cmd_list, timeout_s = 999, exit_on_error = 0, check_return_
     os.system("stty sane")
     logging.debug(output)
 
-def run_cmd_output(cmd):
+def run_cmd_output(cmd, debug_cmd = None):
   """Run a command and return output
   Args:
     cmd          : Command line to execute
   """
   logging.debug(" ".join(cmd))
+  if debug_cmd:
+    debug_cmd.write(" ".join(cmd))
+    debug_cmd.write("\n\n");
+    return
   try:
     output = subprocess.check_output(cmd)
   except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
It is not done yet. I just create PR to see how it works.
Issue #437 
I do not have `vcs` tool. However, I am able to run the script to generate the commands to see how it works.  
For example: 
`run --debug debug.log -tn riscv_unaligned_load_store_test -v -o vcs --sim_opts="+ntb_random_seed=100`

The output is written to `debug.log`. 
```
  1 vcs -file /home/danghai/hhoangda/riscv-dv/vcs.compile.option.f +incdir+/home/danghai/hhoangda/riscv-dv/target/rv32imc +incdir+/home/danghai/hhoangda/riscv-dv/user_extension -f /home/danghai/hhoangda/riscv-dv/files.f -full64 -l /home/danghai    /hhoangda/riscv-dv/vcs/compile.log -Mdir=/home/danghai/hhoangda/riscv-dv/vcs/vcs_simv.csrc -o /home/danghai/hhoangda/riscv-dv/vcs/vcs_simv
  2 
  3  /home/danghai/hhoangda/riscv-dv/vcs/vcs_simv +vcs+lic+wait ### `+ntb_random_seed=100 +ntb_random_seed=2814344772` +UVM_TESTNAME=riscv_instr_base_test  +num_of_tests=1  +start_idx=0  +asm_file_name=vcs/asm_tests/riscv_unaligned_load_store_test  -    l vcs/sim_riscv_unaligned_load_store_test_0.log +UVM_VERBOSITY=UVM_HIGH +instr_cnt=6000 +num_of_sub_program=5 +directed_instr_0=riscv_load_store_rand_instr_stream,20 +directed_instr_1=riscv_load_store_hazard_instr_stream,20 +directed_instr_    2=riscv_multi_page_load_store_instr_stream,5 +directed_instr_3=riscv_mem_region_stress_test,5 +enable_unaligned_load_store=1
  4 
  5 
  6 /opt/riscv/bin/riscv64-unknown-elf-gcc -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles vcs/asm_tests/riscv_unaligned_load_store_test_0.S -I/home/danghai/hhoangda/riscv-dv/user_extension -T/home/danghai/hhoangda/riscv-dv/    scripts/link.ld -o vcs/asm_tests/riscv_unaligned_load_store_test_0.o -mno-strict-align -march=rv32imc -mabi=ilp32
  7 
  8 /opt/riscv/bin/riscv64-unknown-elf-objcopy -O binary vcs/asm_tests/riscv_unaligned_load_store_test_0.o vcs/asm_tests/riscv_unaligned_load_store_test_0.bin
  9 
 10 /opt/riscv/bin/spike --log-commits --isa=rv32imc -l vcs/asm_tests/riscv_unaligned_load_store_test_0.o &> vcs/spike_sim/riscv_unaligned_load_store_test.0.log

```

For my example, I try to overwrite the exist options in yaml: `+ntb_random_seed=100`.  however, it cannot overwrite the exist options in yaml (`+ntb_random_seed=100 +ntb_random_seed=2814344772`), it only appends the options. It may be a bug. By doing this switch, I can detect this bug.
You can remove the tool (qrun, vcs, irun) dependencies. So, you can write CI to track the behavior's command generated from script.