### PR TITLE
run.py: Do not compare csv file when specified -debug switch

### DIFF
--- a/run.py
+++ b/run.py
@@ -487,6 +487,8 @@ def iss_cmp(test_list, iss, output_dir, stop_on_first_error, exp, debug_cmd):
     exp            : Use experimental version
     debug_cmd      : Produce the debug cmd log without running
   """
+  if debug_cmd:
+    return
   iss_list = iss.split(",")
   if len(iss_list) != 2:
     return


### PR DESCRIPTION
Because it does not run command when specified "-debug" switch, it cannot generate the csv file. It has error for comparing the csv file. I mean:
$ run --test riscv_arithmetic_basic_test --iss=spike,ovpsim --debug debug.log
```
sed: can't read out_2020-01-21/spike_sim/riscv_arithmetic_basic_test.0.log: No such file or directory
sed: can't read out_2020-01-21/spike_sim/riscv_arithmetic_basic_test.0.log: No such file or directory
Traceback (most recent call last):
  File "/home/danghai/.local/bin/run", line 11, in <module>
    load_entry_point('riscv-dv', 'console_scripts', 'run')()
  File "/home/danghai/hhoangda/riscv-dv/run.py", line 780, in main
    args.exp, args.debug)
  File "/home/danghai/hhoangda/riscv-dv/run.py", line 504, in iss_cmp
    compare_iss_log(iss_list, log_list, report, stop_on_first_error, exp)
  File "/home/danghai/hhoangda/riscv-dv/run.py", line 518, in compare_iss_log
    process_spike_sim_log(log, csv)
  File "/home/danghai/hhoangda/riscv-dv/scripts/spike_log_to_trace_csv.py", line 54, in process_spike_sim_log
    with open(spike_log, "r") as f, open(csv, "w") as csv_fd:
FileNotFoundError: [Errno 2] No such file or directory: 'out_2020-01-21/spike_sim/riscv_arithmetic_basic_test.0.log'
```

This patch do not let them compare the csv file when using "-debug" switch. The log should be
```
vcs -file /home/danghai/hhoangda/riscv-dv/vcs.compile.option.f +incdir+/home/danghai/hhoangda/riscv-dv/target/rv32imc +incdir+/home/danghai/hhoangda/riscv-dv/user_extension -f /home/danghai/hhoangda/riscv-dv/files.f -full64 -l /home/danghai/hhoangda/riscv-dv/out_2020-01-21/compile.log -Mdir=/home/danghai/hhoangda/riscv-dv/out_2020-01-21/vcs_simv.csrc -o /home/danghai/hhoangda/riscv-dv/out_2020-01-21/vcs_simv   

 /home/danghai/hhoangda/riscv-dv/out_2020-01-21/vcs_simv +vcs+lic+wait  +ntb_random_seed=502621118 +UVM_TESTNAME=riscv_instr_base_test  +num_of_tests=2  +start_idx=0  +asm_file_name=out_2020-01-21/asm_tests/riscv_arithmetic_basic_test  -l out_2020-01-21/sim_riscv_arithmetic_basic_test_0.log +instr_cnt=10000 +num_of_sub_program=0 +directed_instr_0=riscv_int_numeric_corner_stream,4 +no_fence=1 +no_data_page=1 +no_branch_jump=1 +boot_mode=m +no_csr_instr=1


/opt/riscv/bin/riscv64-unknown-elf-gcc -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles out_2020-01-21/asm_tests/riscv_arithmetic_basic_test_0.S -I/home/danghai/hhoangda/riscv-dv/user_extension -T/home/danghai/hhoangda/riscv-dv/scripts/link.ld -o out_2020-01-21/asm_tests/riscv_arithmetic_basic_test_0.o -march=rv32imc -mabi=ilp32

/opt/riscv/bin/riscv64-unknown-elf-objcopy -O binary out_2020-01-21/asm_tests/riscv_arithmetic_basic_test_0.o out_2020-01-21/asm_tests/riscv_arithmetic_basic_test_0.bin

/opt/riscv/bin/riscv64-unknown-elf-gcc -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles out_2020-01-21/asm_tests/riscv_arithmetic_basic_test_1.S -I/home/danghai/hhoangda/riscv-dv/user_extension -T/home/danghai/hhoangda/riscv-dv/scripts/link.ld -o out_2020-01-21/asm_tests/riscv_arithmetic_basic_test_1.o -march=rv32imc -mabi=ilp32

/opt/riscv/bin/riscv64-unknown-elf-objcopy -O binary out_2020-01-21/asm_tests/riscv_arithmetic_basic_test_1.o out_2020-01-21/asm_tests/riscv_arithmetic_basic_test_1.bin

/opt/riscv/bin/spike --log-commits --isa=rv32imc -l out_2020-01-21/asm_tests/riscv_arithmetic_basic_test_0.o &> out_2020-01-21/spike_sim/riscv_arithmetic_basic_test.0.log

/opt/riscv/bin/spike --log-commits --isa=rv32imc -l out_2020-01-21/asm_tests/riscv_arithmetic_basic_test_1.o &> out_2020-01-21/spike_sim/riscv_arithmetic_basic_test.1.log

/home/danghai/riscv-ovpsim/bin/Linux64/riscvOVPsim.exe --controlfile /home/danghai/hhoangda/riscv-dv/target/rv32imc/riscvOVPsim.ic --objfilenoentry out_2020-01-21/asm_tests/riscv_arithmetic_basic_test_0.o --override riscvOVPsim/cpu/PMP_registers=0 --override riscvOVPsim/cpu/simulateexceptions=T --trace --tracechange --traceshowicount --tracemode --traceregs --finishafter 1000000 &> out_2020-01-21/ovpsim_sim/riscv_arithmetic_basic_test.0.log

/home/danghai/riscv-ovpsim/bin/Linux64/riscvOVPsim.exe --controlfile /home/danghai/hhoangda/riscv-dv/target/rv32imc/riscvOVPsim.ic --objfilenoentry out_2020-01-21/asm_tests/riscv_arithmetic_basic_test_1.o --override riscvOVPsim/cpu/PMP_registers=0 --override riscvOVPsim/cpu/simulateexceptions=T --trace --tracechange --traceshowicount --tracemode --traceregs --finishafter 1000000 &> out_2020-01-21/ovpsim_sim/riscv_arithmetic_basic_test.1.log

```