### PR TITLE
Qrun is missing -access=wrc option

### DIFF
--- a/qrun_option.f
+++ b/qrun_option.f
@@ -1,6 +1,7 @@
 -64
 -uvmhome uvm-1.2
 -sv
+-access=rwc+/.
 -mfcu
 -cuname design_cuname
 +define+UVM_REGEX_NO_DPI


### PR DESCRIPTION
irun has `-access +rwc`, qrun is missing this option. 