### PR TITLE
Add pmp configuration object

### DIFF
--- a/src/dv_defines.svh
+++ b/src/dv_defines.svh
@@ -68,6 +68,18 @@
     `DV_CHECK_FATAL(std::randomize(VAR_), MSG_, ID_, with { WITH_C_ })
 `endif
 
+// Shorthand for common this.randomize(foo) + fatal check
+`ifndef DV_CHECK_MEMBER_RANDOMIZE_FATAL
+  `define DV_CHECK_MEMBER_RANDOMIZE_FATAL(VAR_, MSG_="Randomization failed!", ID_=`gfn) \
+    `DV_CHECK_FATAL(this.randomize(VAR_), MSG_, ID_)
+`endif
+
+// Shorthand for common this.randomize(foo) with { } + fatal check
+`ifndef DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL
+  `define DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(VAR_, C_, MSG_="Randomization failed!", ID_=`gfn) \
+    `DV_CHECK_FATAL(this.randomize(VAR_) with {C_}, MSG_, ID_)
+`endif
+
 // for vector processing
 `ifndef VECTOR_INCLUDE
   `define VECTOR_INCLUDE(VCE_INC) \

--- a/src/riscv_asm_program_gen.sv
+++ b/src/riscv_asm_program_gen.sv
@@ -525,6 +525,8 @@ class riscv_asm_program_gen extends uvm_object;
     end
     // Setup trap vector register
     trap_vector_init();
+    // Setup PMP CSRs
+    setup_pmp();
     // Initialize PTE (link page table based on their real physical address)
     if(cfg.virtual_addr_translation_on) begin
       page_table_list.process_page_table(instr);
@@ -590,6 +592,16 @@ class riscv_asm_program_gen extends uvm_object;
              $sformatf("j init_%0s", mode_name.tolower())
             };
     gen_section("mepc_setup", instr);
+  endfunction
+
+  // Setup PMP CSR configuration
+  virtual function void setup_pmp();
+    string instr[$];
+    if (riscv_instr_pkg::support_pmp) begin
+      cfg.pmp_cfg.setup_pmp();
+      cfg.pmp_cfg.gen_pmp_instr(instr, cfg.scratch_reg);
+      gen_section("pmp_setup", instr);
+    end
   endfunction
 
   //---------------------------------------------------------------------------------------

--- a/src/riscv_instr_gen_config.sv
+++ b/src/riscv_instr_gen_config.sv
@@ -91,6 +91,9 @@ class riscv_instr_gen_config extends uvm_object;
   // Vector extension setting
   rand riscv_vector_cfg  vector_cfg;
 
+  // PMP configuration settings
+  rand riscv_pmp_cfg pmp_cfg;
+
   //-----------------------------------------------------------------------------
   //  User space memory region and stack setting
   //-----------------------------------------------------------------------------
@@ -227,7 +230,6 @@ class riscv_instr_gen_config extends uvm_object;
   int                    dist_control_mode;
   int unsigned           category_dist[riscv_instr_category_t];
 
-  uvm_cmdline_processor  inst;
 
   constraint default_c {
     sub_program_instr_cnt.size() == num_of_sub_program;
@@ -540,6 +542,8 @@ class riscv_instr_gen_config extends uvm_object;
       disable_compressed_instr = 1;
     end
     vector_cfg = riscv_vector_cfg::type_id::create("vector_cfg");
+    pmp_cfg = riscv_pmp_cfg::type_id::create("pmp_cfg");
+    pmp_cfg.rand_mode(pmp_cfg.pmp_randomize);
     setup_instr_distribution();
     get_invalid_priv_lvl_csr();
   endfunction
@@ -664,30 +668,6 @@ class riscv_instr_gen_config extends uvm_object;
       if (csr_name[0] inside {invalid_lvl}) begin
         invalid_priv_mode_csrs.push_back(implemented_csr[i]);
       end
-    end
-  endfunction
-
-  // Get an integer argument from comand line
-  function void get_int_arg_value(string cmdline_str, ref int val);
-    string s;
-    if(inst.get_arg_value(cmdline_str, s)) begin
-      val = s.atoi();
-    end
-  endfunction
-
-  // Get a bool argument from comand line
-  function void get_bool_arg_value(string cmdline_str, ref bit val);
-    string s;
-    if(inst.get_arg_value(cmdline_str, s)) begin
-      val = s.atobin();
-    end
-  endfunction
-
-  // Get a hex argument from command line
-  function void get_hex_arg_value(string cmdline_str, ref int val);
-    string s;
-    if(inst.get_arg_value(cmdline_str, s)) begin
-      val = s.atohex();
     end
   endfunction
 

--- a/src/riscv_instr_pkg.sv
+++ b/src/riscv_instr_pkg.sv
@@ -26,12 +26,34 @@ package riscv_instr_pkg;
 
   `define include_file(f) `include `"f`"
 
+  uvm_cmdline_processor  inst;
+
   // Data section setting
   typedef struct {
     string         name;
     int unsigned   size_in_bytes;
     bit [2:0]      xwr; // Excutable,Writable,Readale
   } mem_region_t;
+
+  // PMP address matching mode
+  typedef enum bit [1:0] {
+    OFF   = 2'b00,
+    TOR   = 2'b01,
+    NA4   = 2'b10,
+    NAPOT = 2'b11
+  } pmp_addr_mode_t;
+
+  // PMP configuration register layout
+  // This configuration struct includes the pmp address for simplicity
+  typedef struct{
+    rand bit                   l;
+    bit [1:0]                  zero;
+    rand pmp_addr_mode_t       a;
+    rand bit                   x;
+    rand bit                   w;
+    rand bit                   r;
+    rand bit [33:0]            addr;
+  } pmp_cfg_reg_t;
 
   typedef enum bit [3:0] {
     BARE = 4'b0000,
@@ -1069,6 +1091,30 @@ package riscv_instr_pkg;
     end
   endfunction
 
+  // Get an integer argument from comand line
+  function automatic void get_int_arg_value(string cmdline_str, ref int val);
+    string s;
+    if(inst.get_arg_value(cmdline_str, s)) begin
+      val = s.atoi();
+    end
+  endfunction
+
+  // Get a bool argument from comand line
+  function automatic void get_bool_arg_value(string cmdline_str, ref bit val);
+    string s;
+    if(inst.get_arg_value(cmdline_str, s)) begin
+      val = s.atobin();
+    end
+  endfunction
+
+  // Get a hex argument from command line
+  function automatic void get_hex_arg_value(string cmdline_str, ref int val);
+    string s;
+    if(inst.get_arg_value(cmdline_str, s)) begin
+      val = s.atohex();
+    end
+  endfunction
+
   riscv_reg_t all_gpr[] = {ZERO, RA, SP, GP, TP, T0, T1, T2, S0, S1, A0,
                            A1, A2, A3, A4, A5, A6, A7, S2, S3, S4, S5, S6,
                            S7, S8, S9, S10, S11, T3, T4, T5, T6};
@@ -1081,6 +1127,7 @@ package riscv_instr_pkg;
   };
 
   `include "riscv_vector_cfg.sv"
+  `include "riscv_pmp_cfg.sv"
   typedef class riscv_instr;
   `include "riscv_instr_gen_config.sv"
   `include "isa/riscv_instr.sv"

--- a/src/riscv_pmp_cfg.sv
+++ b/src/riscv_pmp_cfg.sv
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class riscv_pmp_cfg extends uvm_object;
+
+  // default to a single PMP region
+  rand int pmp_num_regions = 1;
+  // default to granularity of 0 (4 bytes grain)
+  rand int pmp_granularity = 0;
+  // enable bit for pmp randomization
+  bit pmp_randomize = 0;
+  // pmp CSR configurations
+  rand pmp_cfg_reg_t pmp_cfg[];
+
+  // used to parse addr_mode configuration from cmdline
+  typedef uvm_enum_wrapper#(pmp_addr_mode_t) addr_mode_wrapper;
+  pmp_addr_mode_t addr_mode;
+
+  `uvm_object_utils_begin(riscv_pmp_cfg)
+    `uvm_field_int(pmp_num_regions, UVM_DEFAULT)
+    `uvm_field_int(pmp_granularity, UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  // constraints
+  constraint sanity_c {
+    pmp_num_regions inside {[1 : 16]};
+    pmp_granularity inside {[0 : XLEN + 3]};
+  }
+
+  // TODO(udinator) move these constraints to post_randomize() to save performance
+  constraint xwr_c {
+    foreach (pmp_cfg[i]) {
+      !(pmp_cfg[i].w && !pmp_cfg[i].r);
+    }
+  }
+
+  constraint grain_addr_mode_c {
+    foreach (pmp_cfg[i]) {
+      (pmp_granularity >= 1) -> (pmp_cfg[i].a != NA4);
+    }
+  }
+
+  function new(string name = "");
+    string s;
+    super.new(name);
+    get_bool_arg_value("+pmp_randomize=", pmp_randomize);
+    pmp_cfg = new[pmp_num_regions];
+    if (!pmp_randomize) begin
+      set_defaults();
+    end
+  endfunction
+
+  // TODO(udinator) partition address space to map to all active pmp_addr CSRs
+  // TODO(udinator) set pmp address defaults
+  function void set_defaults();
+    foreach(pmp_cfg[i]) begin
+      pmp_cfg[i].l    = 1'b0;
+      pmp_cfg[i].a    = TOR;
+      pmp_cfg[i].x    = 1'b1;
+      pmp_cfg[i].w    = 1'b1;
+      pmp_cfg[i].r    = 1'b1;
+      pmp_cfg[i].addr = 34'h3FFFFFFFF;
+    end
+  endfunction
+
+  function void setup_pmp();
+    string pmp_region;
+    get_int_arg_value("+pmp_num_regions=", pmp_num_regions);
+    get_int_arg_value("+pmp_granularity=", pmp_granularity);
+    // TODO(udinator) - parse the pmp configuration values
+  endfunction
+
+  // This function parses the pmp_cfg[] array to generate the actual instructions to set up
+  // the PMP CSR registers.
+  // Since either 4 (in rv32) or 8 (in rv64) PMP configuration registers fit into one physical
+  // CSR, this function waits until it has reached this maximum to write to the physical CSR to
+  // save some extraneous instructions from being performed.
+  function void gen_pmp_instr(ref string instr[$], riscv_reg_t scratch_reg);
+    int cfg_per_csr = XLEN / 4;
+    bit [XLEN - 1 : 0] pmp_word;
+    bit [XLEN - 1 : 0] cfg_bitmask;
+    bit [7 : 0] cfg_byte;
+    riscv_instr_pkg::privileged_reg_t base_pmp_addr = PMPADDR0;
+    riscv_instr_pkg::privileged_reg_t base_pmpcfg_addr = PMPCFG0;
+    int pmp_id;
+    foreach (pmp_cfg[i]) begin
+      // TODO(udijnator) condense this calculations if possible
+      pmp_id = i / cfg_per_csr;
+      cfg_byte = {pmp_cfg[i].l, pmp_cfg[i].zero, pmp_cfg[i].a,
+                  pmp_cfg[i].x, pmp_cfg[i].w, pmp_cfg[i].r};
+      `uvm_info(`gfn, $sformatf("cfg_byte: 0x%0x", cfg_byte), UVM_DEBUG)
+      cfg_bitmask = cfg_byte << ((i % cfg_per_csr) * 8);
+      `uvm_info(`gfn, $sformatf("cfg_bitmask: 0x%0x", cfg_bitmask), UVM_DEBUG)
+      pmp_word = pmp_word | cfg_bitmask;
+      `uvm_info(`gfn, $sformatf("pmp_word: 0x%0x", pmp_word), UVM_DEBUG)
+      cfg_bitmask = 0;
+      //TODO (udinator) - add rv64 support for pmpaddr writes
+      instr.push_back($sformatf("li x%0d, 0x%0x", scratch_reg, pmp_cfg[i].addr[XLEN + 1 : 2]));
+      instr.push_back($sformatf("csrw 0x%0x, x%0d", base_pmp_addr + i, scratch_reg));
+      // short circuit if end of list
+      if (i == pmp_cfg.size() - 1) begin
+        instr.push_back($sformatf("li x%0d, 0x%0x", scratch_reg, pmp_word));
+        instr.push_back($sformatf("csrw 0x%0x, x%0d",
+                                  base_pmpcfg_addr + pmp_id),
+                                  scratch_reg));
+        return;
+      end else if ((i + 1) % cfg_per_csr == 0) begin
+        // if we've filled up pmp_word, write to the corresponding CSR
+        instr.push_back($sformatf("li x%0d, 0x%0x", scratch_reg, pmp_word));
+        instr.push_back($sformatf("csrw 0x%0x, x%0d",
+                                  base_pmpcfg_addr + pmp_id),
+                                  scratch_reg));
+        pmp_word = 0;
+      end
+    end
+  endfunction
+
+endclass

--- a/target/ml/riscv_core_setting.sv
+++ b/target/ml/riscv_core_setting.sv
@@ -39,6 +39,9 @@ mtvec_mode_t supported_interrupt_mode[$] = {DIRECT, VECTORED};
 // supported
 int max_interrupt_vector_num = 16;
 
+// Physical memory protection support
+bit support_pmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/rv32i/riscv_core_setting.sv
+++ b/target/rv32i/riscv_core_setting.sv
@@ -39,6 +39,9 @@ mtvec_mode_t supported_interrupt_mode[$] = {DIRECT, VECTORED};
 // supported
 int max_interrupt_vector_num = 16;
 
+// Physical memory protection support
+bit support_pmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/rv32imc/riscv_core_setting.sv
+++ b/target/rv32imc/riscv_core_setting.sv
@@ -39,6 +39,9 @@ mtvec_mode_t supported_interrupt_mode[$] = {DIRECT, VECTORED};
 // supported
 int max_interrupt_vector_num = 16;
 
+// Physical memory protection support
+bit support_pmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/rv64gc/riscv_core_setting.sv
+++ b/target/rv64gc/riscv_core_setting.sv
@@ -39,6 +39,9 @@ mtvec_mode_t supported_interrupt_mode[$] = {DIRECT, VECTORED};
 // supported
 int max_interrupt_vector_num = 16;
 
+// Physical memory protection support
+bit support_pmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/rv64gcv/riscv_core_setting.sv
+++ b/target/rv64gcv/riscv_core_setting.sv
@@ -39,6 +39,9 @@ mtvec_mode_t supported_interrupt_mode[$] = {DIRECT, VECTORED};
 // supported
 int max_interrupt_vector_num = 16;
 
+// Physical memory protection support
+bit support_pmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/rv64imc/riscv_core_setting.sv
+++ b/target/rv64imc/riscv_core_setting.sv
@@ -39,6 +39,9 @@ mtvec_mode_t supported_interrupt_mode[$] = {DIRECT, VECTORED};
 // supported
 int max_interrupt_vector_num = 16;
 
+// Physical memory protection support
+bit support_pmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 


### PR DESCRIPTION
- added some new randomization macros for ease of use
- the uvm_cmdline_processor instance has been moved to the riscv_instr_pkg to allow the command line parsing functions to be used by various configuration objects as needed
- basic pmp configuration object added - with just the default values for now