### PR TITLE
The "solve...before" constraints should be modified.

### DIFF
--- a/src/riscv_instr_gen_config.sv
+++ b/src/riscv_instr_gen_config.sv
@@ -379,8 +379,11 @@ class riscv_instr_gen_config extends uvm_object;
     unique {gpr};
   }
 
-  constraint addr_translaction_c {
+  constraint addr_translaction_rnd_order_c {
     solve init_privileged_mode before virtual_addr_translation_on;
+  }
+  
+  constraint addr_translaction_c {
     if ((init_privileged_mode != MACHINE_MODE) && (SATP_MODE != BARE)) {
       virtual_addr_translation_on == 1'b1;
     } else {
@@ -517,6 +520,7 @@ class riscv_instr_gen_config extends uvm_object;
                   $sformatf("Illegal boot mode option - %0s", boot_mode_opts))
       endcase
       init_privileged_mode.rand_mode(0);
+      addr_translaction_rnd_order_c.constraint_mode(0);
     end
     `uvm_info(`gfn, $sformatf("riscv_instr_pkg::supported_privileged_mode = %0d",
                    riscv_instr_pkg::supported_privileged_mode.size()), UVM_LOW)

--- a/src/riscv_load_store_instr_lib.sv
+++ b/src/riscv_load_store_instr_lib.sv
@@ -39,8 +39,11 @@ class riscv_load_store_base_instr_stream extends riscv_mem_access_stream;
 
   `uvm_object_utils(riscv_load_store_base_instr_stream)
 
-  constraint sp_c {
+  constraint sp_rnd_order_c {
     solve use_sp_as_rs1 before rs1_reg;
+  }
+  
+  constraint sp_c {
     use_sp_as_rs1 dist {1 := 1, 0 := 2};
     if (use_sp_as_rs1) {
       rs1_reg == SP;
@@ -97,6 +100,7 @@ class riscv_load_store_base_instr_stream extends riscv_mem_access_stream;
     if (SP inside {cfg.reserved_regs, reserved_rd}) begin
       use_sp_as_rs1 = 0;
       use_sp_as_rs1.rand_mode(0);
+      sp_rnd_order_c.constraint_mode(0);
     end
   endfunction
 

--- a/test/riscv_instr_test_lib.sv
+++ b/test/riscv_instr_test_lib.sv
@@ -52,7 +52,9 @@ class riscv_ml_test extends riscv_instr_base_test;
     cfg.init_privileged_mode = MACHINE_MODE;
     cfg.init_privileged_mode.rand_mode(0);
     cfg.enable_unaligned_load_store = 1'b1;
+    cfg.addr_translaction_rnd_order_c.constraint_mode(0);
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
+	cfg.addr_translaction_rnd_order_c.constraint_mode(1);
     `uvm_info(`gfn, $sformatf("riscv_instr_gen_config is randomized:\n%0s",
                     cfg.sprint()), UVM_LOW)
   endfunction


### PR DESCRIPTION
According to the SV 1800-2017 standard using non random variable as a solve...before argument is not allowed. In two cases - for variable "init_privileged_mode" and "use_sp_as_rs1 " the randomization possibilities are disabled by rand_mode(0) but the "solve...before" constraint is still active causing compilation problems. To fix that the "solve...before" constraint should be divided and the ordering part should be disabled before randomization. After randomization, if it is necessary the "solve...before" constraint can be re-enabled.

Kind regards,
Darek