### PR TITLE
Don't change input file in spike_log_to_trace_csv.py

### DIFF
--- a/scripts/spike_log_to_trace_csv.py
+++ b/scripts/spike_log_to_trace_csv.py
@@ -34,70 +34,6 @@ ILLE_RE  = re.compile(r"trap_illegal_instruction")
 
 LOGGER = logging.getLogger()
 
-def process_spike_sim_log(spike_log, csv, full_trace = 0):
-  """Process SPIKE simulation log.
-
-  Extract instruction and affected register information from spike simulation
-  log and save to a list.
-  """
-  logging.info("Processing spike log : %s" % spike_log)
-  instr_cnt = 0
-  spike_instr = ""
-
-  # Remove all the init spike boot instructions
-  cmd = ("sed -i '/core.*0x0000000000001010/,$!d' %s" % spike_log)
-  os.system(cmd)
-  # Remove all instructions after ecall (end of program excecution)
-  cmd = ("sed -i '/ecall/q' %s" % spike_log)
-  os.system(cmd)
-
-  with open(spike_log, "r") as f, open(csv, "w") as csv_fd:
-    trace_csv = RiscvInstructionTraceCsv(csv_fd)
-    trace_csv.start_new_trace()
-    for line in f:
-      # Extract instruction infromation
-      m = CORE_RE.search(line)
-      if m:
-        instr_cnt += 1
-        spike_instr = m.group("instr").replace("pc + ", "")
-        spike_instr = spike_instr.replace("pc - ", "-")
-        rv_instr_trace = RiscvInstructionTraceEntry()
-        rv_instr_trace.pc = m.group("addr")
-        rv_instr_trace.instr_str = spike_instr
-        rv_instr_trace.binary = m.group("bin")
-        if full_trace:
-          rv_instr_trace.instr = spike_instr.split(" ")[0]
-          rv_instr_trace.operand = spike_instr[len(rv_instr_trace.instr):]
-          rv_instr_trace.operand = rv_instr_trace.operand.replace(" ", "")
-          rv_instr_trace.instr, rv_instr_trace.operand = convert_pseudo_instr(
-              rv_instr_trace.instr, rv_instr_trace.operand, rv_instr_trace.binary)
-          process_instr(rv_instr_trace)
-        if spike_instr == "wfi":
-          trace_csv.write_trace_entry(rv_instr_trace)
-          continue
-        nextline = f.readline()
-        if nextline != "":
-          if ILLE_RE.search(nextline):
-            if full_trace:
-              logging.debug("Illegal instruction: %s, opcode:%s" %
-                            (rv_instr_trace.instr_str, rv_instr_trace.binary))
-              trace_csv.write_trace_entry(rv_instr_trace)
-            continue
-          m = RD_RE.search(nextline)
-          if m:
-            # Extract RD information
-            rv_instr_trace.gpr.append(
-              gpr_to_abi(m.group("reg").replace(" ","")) + ":" + m.group("val"))
-            rv_instr_trace.mode = m.group("pri")
-          else:
-            # If full trace is not enabled, skip the entry that doesn't have
-            # architectural state update.
-            if not full_trace:
-              continue
-        trace_csv.write_trace_entry(rv_instr_trace)
-  logging.info("Processed instruction count : %d" % instr_cnt)
-  logging.info("CSV saved to : %s" % csv)
-
 
 def process_instr(trace):
   if trace.instr == "jal":
@@ -111,6 +47,171 @@ def process_instr(trace):
     trace.operand = trace.operand[0:idx+1] + imm
   trace.operand = trace.operand.replace("(", ",")
   trace.operand = trace.operand.replace(")", "")
+
+
+def read_spike_instr(match, full_trace):
+  '''Unpack a regex match for CORE_RE to a RiscvInstructionTraceEntry
+
+  If full_trace is true, extract operand data from the disassembled
+  instruction.
+
+  '''
+
+  # Extract the disassembled instruction.
+  disasm = match.group('instr')
+
+  # Spike's disassembler shows a relative jump as something like "j pc +
+  # 0x123" or "j pc - 0x123". We just want the relative offset.
+  disasm = disasm.replace('pc + ', '').replace('pc - ', '-')
+
+  instr = RiscvInstructionTraceEntry()
+  instr.pc = match.group('addr')
+  instr.instr_str = disasm
+  instr.binary = match.group('bin')
+
+  if full_trace:
+    opcode = disasm.split(' ')[0]
+    operand = disasm[len(opcode):].replace(' ', '')
+    instr.instr, instr.operand = \
+      convert_pseudo_instr(opcode, operand, instr.binary)
+
+    process_instr(instr)
+
+  return instr
+
+
+def read_spike_trace(path, full_trace):
+  '''Read a Spike simulation log at <path>, yielding executed instructions.
+
+  This assumes that the log was generated with the -l and --log-commits options
+  to Spike.
+
+  If full_trace is true, extract operands from the disassembled instructions.
+
+  Since Spike has a strange trampoline that always runs at the start, we skip
+  instructions up to and including the one at PC 0x1010 (the end of the
+  trampoline). At the end of a DV program, there's an ECALL instruction, which
+  we take as a signal to stop checking, so we ditch everything that follows
+  that instruction.
+
+  This function yields instructions as it parses them as tuples of the form
+  (entry, illegal). entry is a RiscvInstructionTraceEntry. illegal is a
+  boolean, which is true if the instruction caused an illegal instruction trap.
+
+  '''
+
+  # This loop is a simple FSM with states TRAMPOLINE, INSTR, EFFECT. The idea
+  # is that we're in state TRAMPOLINE until we get to the end of Spike's
+  # trampoline, then we switch between INSTR (where we expect to read an
+  # instruction) and EFFECT (where we expect to read commit information).
+  #
+  # We yield a RiscvInstructionTraceEntry object each time we leave EFFECT
+  # (going back to INSTR), we loop back from INSTR to itself, or we get to the
+  # end of the file and have an instruction in hand.
+  #
+  # On entry to the loop body, we are in state TRAMPOLINE if in_trampoline is
+  # true. Otherwise, we are in state EFFECT if instr is not None, otherwise we
+  # are in state INSTR.
+
+  end_trampoline_re = re.compile(r'core.*: 0x0*1010 ')
+
+  in_trampoline = True
+  instr = None
+
+  with open(path, 'r') as handle:
+    for line in handle:
+      if in_trampoline:
+        # The TRAMPOLINE state
+        if end_trampoline_re.match(line):
+          in_trampoline = False
+        continue
+
+      if instr is None:
+        # The INSTR state. We expect to see a line matching CORE_RE. We'll
+        # discard any other lines.
+        instr_match = CORE_RE.match(line)
+        if not instr_match:
+          continue
+
+        instr = read_spike_instr(instr_match, full_trace)
+
+        # If instr.instr_str is 'ecall', we should stop.
+        if instr.instr_str == 'ecall':
+          break
+
+        continue
+
+      # The EFFECT state. If the line matches CORE_RE, we should have been in
+      # state INSTR, so we yield the instruction we had, read the new
+      # instruction and continue. As above, if the new instruction is 'ecall',
+      # we need to stop immediately.
+      instr_match = CORE_RE.match(line)
+      if instr_match:
+        yield (instr, False)
+        instr = read_spike_instr(instr_match, full_trace)
+        if instr.instr_str == 'ecall':
+          break
+        continue
+
+      # The line doesn't match CORE_RE, so we are definitely on a follow-on
+      # line in the log. First, check for illegal instructions
+      if 'trap_illegal_instruction' in line:
+        yield (instr, True)
+        instr = None
+        continue
+
+      # The instruction seems to have been fine. Do we have commit data (from
+      # the --log-commits Spike option)?
+      commit_match = RD_RE.match(line)
+      if commit_match:
+        instr.gpr.append(gpr_to_abi(commit_match.group('reg')
+                                    .replace(' ', '')) +
+                         ':' + commit_match.group('val'))
+        instr.mode = commit_match.group('pri')
+
+    # At EOF, we might have an instruction in hand. Yield it if so.
+    if instr is not None:
+      yield (instr, False)
+
+
+def process_spike_sim_log(spike_log, csv, full_trace = 0):
+  """Process SPIKE simulation log.
+
+  Extract instruction and affected register information from spike simulation
+  log and write the results to a CSV file at csv. Returns the number of
+  instructions written.
+
+  """
+  logging.info("Processing spike log : %s" % spike_log)
+  instrs_in = 0
+  instrs_out = 0
+
+  with open(csv, "w") as csv_fd:
+    trace_csv = RiscvInstructionTraceCsv(csv_fd)
+    trace_csv.start_new_trace()
+
+    for (entry, illegal) in read_spike_trace(spike_log, full_trace):
+      instrs_in += 1
+
+      if illegal and full_trace:
+        logging.debug("Illegal instruction: {}, opcode:{}"
+                      .format(entry.instr_str, entry.binary))
+
+      # Instructions that cause no architectural update (which includes illegal
+      # instructions) are ignored if full_trace is false.
+      #
+      # We say that an instruction caused an architectural update if either we
+      # saw a commit line (in which case, entry.gpr will contain a single
+      # entry) or the instruction was 'wfi' or 'ecall'.
+      if not (full_trace or entry.gpr or entry.instr_str in ['wfi', 'ecall']):
+        continue
+
+      trace_csv.write_trace_entry(entry)
+      instrs_out += 1
+
+  logging.info("Processed instruction count : %d" % instrs_in)
+  logging.info("CSV saved to : %s" % csv)
+  return instrs_out
 
 
 def main():


### PR DESCRIPTION
Yesterday, I spent half an hour getting very confused about why my
Spike logs (which didn't some magic lines) were getting replaced with
the empty file when I tried to use them as inputs to this script.

This patch replaces the 'sed -i' invocations with equivalent logic in
the actual Python. It also factors out the code that parses the trace
from the code that uses it, which I think makes things a bit more
obvious.

Finally, the patch adds lots of comments, explaining the control flow:
when writing this, I really struggled to figure out what the existing
code was trying to do with things like WFI and ECALL instructions and
architectural updates. Hopefully, this is much clearer now.

Other than not rewriting input files, there are two known changes
caused by this patch. Firstly, the previous code wrote out the jr
instruction at 0x1010, but only if called with full_trace=1. I don't
believe that can have been intentional, so I've picked the behaviour
that is used when we compare traces in Ibex.

Secondly, the instruction counting has changed. I think that the
counting previously included the jump at 0x1010 (which we now don't
write out). We don't include that any more, so the "Processed
instruction count" message will decrease by 1.