### PR TITLE
[cov] tag coverage database directories with <test_id>

### DIFF
--- a/run.py
+++ b/run.py
@@ -250,6 +250,7 @@ def do_simulate(sim_cmd, test_list, cwd, sim_opts, seed_yaml, seed, csr_file,
           if verbose:
             cmd += "+UVM_VERBOSITY=UVM_HIGH "
           cmd = re.sub("<seed>", str(rand_seed), cmd)
+          cmd = re.sub("<test_id>", test_id, cmd)
           sim_seed[test_id] = str(rand_seed)
           if "gen_opts" in test:
             cmd += test['gen_opts']

--- a/yaml/simulator.yaml
+++ b/yaml/simulator.yaml
@@ -29,7 +29,7 @@
     cmd: >
       <out>/vcs_simv +vcs+lic+wait <sim_opts> +ntb_random_seed=<seed> <cov_opts>
     cov_opts: >
-      -cm_dir <out>/test.vdb -cm_log /dev/null -cm_name test_<seed>
+      -cm_dir <out>/test.vdb -cm_log /dev/null -cm_name test_<seed>_<test_id>
 
 - tool: ius
   compile:


### PR DESCRIPTION
Renames coverage database output directories to `test_<test_id>` from `test_<seed>` to provide uniquification of names for use cases where a same seed value is passed to every test iteration (like in Ibex environment).