### PR TITLE
Update style check

### DIFF
--- a/run.py
+++ b/run.py
@@ -817,6 +817,10 @@ def main():
     # Create output directory
     output_dir = create_output(args.o, args.noclean)
 
+    logging.debug("Run style check")
+    style_err = run_cmd("verilog_style/run.sh")
+    if style_err: logging.info("Found style error: \nERROR: " + style_err)
+
     # Run any handcoded/directed assembly tests specified by args.asm_tests
     if args.asm_tests != "":
       asm_test = args.asm_tests.split(',')

--- a/src/isa/riscv_b_instr.sv
+++ b/src/isa/riscv_b_instr.sv
@@ -109,6 +109,7 @@ class riscv_b_instr extends riscv_instr;
         asm_str_super = $sformatf("%0s%0s, %0s, %0s, %0s", asm_str, rd.name(), rs1.name(),
                                   rs2.name(), rs3.name());
       end
+      default: `uvm_info(`gfn, $sformatf("Unsupported format %0s", format.name()), UVM_LOW)
     endcase
 
     if (comment != "") begin

--- a/src/isa/riscv_compressed_instr.sv
+++ b/src/isa/riscv_compressed_instr.sv
@@ -217,6 +217,7 @@ class riscv_compressed_instr extends riscv_instr;
           end
         CJ_FORMAT:
           asm_str = $sformatf("%0s%0s", asm_str, get_imm());
+        default: `uvm_info(`gfn, $sformatf("Unsupported format %0s", format.name()), UVM_LOW)
       endcase
     end else begin
       // For EBREAK,C.EBREAK, making sure pc+4 is a valid instruction boundary

--- a/src/isa/riscv_floating_point_instr.sv
+++ b/src/isa/riscv_floating_point_instr.sv
@@ -138,6 +138,7 @@ class riscv_floating_point_instr extends riscv_instr;
         has_fs1 = 1'b0;
         has_fd = 1'b0;
       end
+      default: `uvm_info(`gfn, $sformatf("Unsupported format %0s", format.name()), UVM_LOW)
     endcase
   endfunction
 

--- a/src/isa/riscv_instr.sv
+++ b/src/isa/riscv_instr.sv
@@ -374,6 +374,7 @@ class riscv_instr extends uvm_object;
           end else begin
             asm_str = $sformatf("%0s%0s, %0s, %0s", asm_str, rd.name(), rs1.name(), rs2.name());
           end
+        default: `uvm_fatal(`gfn, $sformatf("Unsupported format %0s", format.name()))
       endcase
     end else begin
       // For EBREAK,C.EBREAK, making sure pc+4 is a valid instruction boundary
@@ -580,6 +581,7 @@ class riscv_instr extends uvm_object;
         else
           binary = $sformatf("%8h", {get_func7(), rs2, rs1, get_func3(), rd, get_opcode()});
       end
+      default: `uvm_fatal(`gfn, $sformatf("Unsupported format %0s", format.name()))
     endcase
     return {prefix, binary};
   endfunction

--- a/src/isa/riscv_vector_instr.sv
+++ b/src/isa/riscv_vector_instr.sv
@@ -103,6 +103,7 @@ class riscv_vector_instr extends riscv_floating_point_instr;
             VV: asm_str = $sformatf("vmv.v.v %s,%s", vd.name(), vs1.name());
             VX: asm_str = $sformatf("vmv.v.x %s,%s", vd.name(), rs1.name());
             VI: asm_str = $sformatf("vmv.v.i %s,%s", vd.name(), imm_str);
+            default: `uvm_info(`gfn, $sformatf("Unsupported va_variant %0s", va_variant), UVM_LOW)
           endcase
         end else if (instr_name == VFMV) begin
           asm_str = $sformatf("vfmv.v.f %s,%s", vd.name(), fs1.name());
@@ -156,6 +157,7 @@ class riscv_vector_instr extends riscv_floating_point_instr;
           end
         end
       end
+      default: `uvm_info(`gfn, $sformatf("Unsupported format %0s", format.name()), UVM_LOW)
     endcase
     if(comment != "") begin
       asm_str = {asm_str, " #",comment};

--- a/src/riscv_instr_gen_config.sv
+++ b/src/riscv_instr_gen_config.sv
@@ -396,7 +396,7 @@ class riscv_instr_gen_config extends uvm_object;
   constraint addr_translaction_rnd_order_c {
     solve init_privileged_mode before virtual_addr_translation_on;
   }
-  
+
   constraint addr_translaction_c {
     if ((init_privileged_mode != MACHINE_MODE) && (SATP_MODE != BARE)) {
       virtual_addr_translation_on == 1'b1;

--- a/src/riscv_instr_sequence.sv
+++ b/src/riscv_instr_sequence.sv
@@ -305,6 +305,7 @@ class riscv_instr_sequence extends uvm_sequence;
       C_JALR : str = {prefix, $sformatf("c.jalr x%0d", ra)};
       C_JR   : str = {prefix, $sformatf("c.jr x%0d", ra)};
       JALR   : str = {prefix, $sformatf("jalr x%0d, x%0d, 0", ra, ra)};
+      default: `uvm_fatal(`gfn, $sformatf("Unsupported jump_instr %0s", jump_instr[i]))
     endcase
     instr_string_list.push_back(str);
   endfunction

--- a/src/riscv_page_table_entry.sv
+++ b/src/riscv_page_table_entry.sv
@@ -146,6 +146,7 @@ class riscv_page_table_entry#(satp_mode_t MODE = SV39) extends uvm_object;
       1 : return PPN0_WIDTH;
       2 : return PPN0_WIDTH + PPN1_WIDTH;
       3 : return PPN0_WIDTH + PPN1_WIDTH + PPN2_WIDTH;
+      default: `uvm_fatal(`gfn, $sformatf("Unsupported page_level %0x", page_level))
     endcase
   endfunction
 

--- a/src/riscv_pmp_cfg.sv
+++ b/src/riscv_pmp_cfg.sv
@@ -163,6 +163,7 @@ class riscv_pmp_cfg extends uvm_object;
       64: begin
         return {10'b0, shifted_addr[XLEN - 11 : 0]};
       end
+      default: `uvm_fatal(`gfn, $sformatf("Unsupported XLEN %0s", XLEN))
     endcase
   endfunction
 

--- a/verilog_style/exclude_filelist.f
+++ b/verilog_style/exclude_filelist.f
@@ -5,6 +5,3 @@ riscv_instr_cover_group.sv
 riscv_instr_pkg.sv
 # tool does not support included file very well. Issue at github.com/google/verible/issues/178
 riscv_custom_instr_enum.sv
-# tool bug. Issue at github.com/google/verible/issues/172
-riscv_instr_stream.sv
-riscv_reg.sv


### PR DESCRIPTION
1. Add to run style check when you run sim
2. Update codes for new rule below in latest style tool
 - Explicitly define a default case for every case statement
3. Update exclude_filelist as a tool bug has been fixed

Everyone needs to run ./verilog_style/build-verible.sh to get the latest
version

Signed-off-by: Weicai Yang <weicai@google.com>