### PR TITLE
Fix a typo in riscvOVPsim

### DIFF
--- a/target/rv32imcb/riscvOVPsim.ic
+++ b/target/rv32imcb/riscvOVPsim.ic
@@ -1,6 +1,6 @@
 # riscOVPsim configuration file converted from YAML
 --variant RV32I
---override iscvOVPsim/cpu/add_Extensions=MCB
+--override riscvOVPsim/cpu/add_Extensions=MCB
 --override riscvOVPsim/cpu/misa_MXL=1
 --override riscvOVPsim/cpu/misa_MXL_mask=0x0 # 0
 --override riscvOVPsim/cpu/misa_Extensions_mask=0x0 # 0


### PR DESCRIPTION
ovpsim can support b-ext now #520