### PR TITLE
Change dynamic array parameters to const.

### DIFF
--- a/target/ml/riscv_core_setting.sv
+++ b/target/ml/riscv_core_setting.sv
@@ -70,7 +70,7 @@ parameter int NUM_HARTS = 1;
 `ifdef DSIM
 privileged_reg_t implemented_csr[] = {
 `else
-parameter privileged_reg_t implemented_csr[] = {
+const privileged_reg_t implemented_csr[] = {
 `endif
     // Machine mode mode CSR
     MVENDORID,  // Vendor ID
@@ -96,7 +96,7 @@ parameter privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 interrupt_cause_t implemented_interrupt[] = {
 `else
-parameter interrupt_cause_t implemented_interrupt[] = {
+const interrupt_cause_t implemented_interrupt[] = {
 `endif
     M_SOFTWARE_INTR,
     M_TIMER_INTR,
@@ -106,7 +106,7 @@ parameter interrupt_cause_t implemented_interrupt[] = {
 `ifdef DSIM
 exception_cause_t implemented_exception[] = {
 `else
-parameter exception_cause_t implemented_exception[] = {
+const exception_cause_t implemented_exception[] = {
 `endif
     INSTRUCTION_ACCESS_FAULT,
     ILLEGAL_INSTRUCTION,

--- a/target/multi_harts/riscv_core_setting.sv
+++ b/target/multi_harts/riscv_core_setting.sv
@@ -71,7 +71,7 @@ parameter int NUM_HARTS = 2;
 `ifdef DSIM
 privileged_reg_t implemented_csr[] = {
 `else
-parameter privileged_reg_t implemented_csr[] = {
+const privileged_reg_t implemented_csr[] = {
 `endif
     // Machine mode mode CSR
     MVENDORID,  // Vendor ID
@@ -97,7 +97,7 @@ parameter privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 interrupt_cause_t implemented_interrupt[] = {
 `else
-parameter interrupt_cause_t implemented_interrupt[] = {
+const interrupt_cause_t implemented_interrupt[] = {
 `endif
     M_SOFTWARE_INTR,
     M_TIMER_INTR,
@@ -107,7 +107,7 @@ parameter interrupt_cause_t implemented_interrupt[] = {
 `ifdef DSIM
 exception_cause_t implemented_exception[] = {
 `else
-parameter exception_cause_t implemented_exception[] = {
+const exception_cause_t implemented_exception[] = {
 `endif
     INSTRUCTION_ACCESS_FAULT,
     ILLEGAL_INSTRUCTION,

--- a/target/rv32i/riscv_core_setting.sv
+++ b/target/rv32i/riscv_core_setting.sv
@@ -70,7 +70,7 @@ parameter int NUM_HARTS = 1;
 `ifdef DSIM
 privileged_reg_t implemented_csr[] = {
 `else
-parameter privileged_reg_t implemented_csr[] = {
+const privileged_reg_t implemented_csr[] = {
 `endif
     // Machine mode mode CSR
     MVENDORID,  // Vendor ID
@@ -96,7 +96,7 @@ parameter privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 interrupt_cause_t implemented_interrupt[] = {
 `else
-parameter interrupt_cause_t implemented_interrupt[] = {
+const interrupt_cause_t implemented_interrupt[] = {
 `endif
     M_SOFTWARE_INTR,
     M_TIMER_INTR,
@@ -106,7 +106,7 @@ parameter interrupt_cause_t implemented_interrupt[] = {
 `ifdef DSIM
 exception_cause_t implemented_exception[] = {
 `else
-parameter exception_cause_t implemented_exception[] = {
+const exception_cause_t implemented_exception[] = {
 `endif
     INSTRUCTION_ADDRESS_MISALIGNED,
     INSTRUCTION_ACCESS_FAULT,

--- a/target/rv32imc/riscv_core_setting.sv
+++ b/target/rv32imc/riscv_core_setting.sv
@@ -71,7 +71,7 @@ parameter int NUM_HARTS = 1;
 `ifdef DSIM
 privileged_reg_t implemented_csr[] = {
 `else
-parameter privileged_reg_t implemented_csr[] = {
+const privileged_reg_t implemented_csr[] = {
 `endif
     // Machine mode mode CSR
     MVENDORID,  // Vendor ID
@@ -97,7 +97,7 @@ parameter privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 interrupt_cause_t implemented_interrupt[] = {
 `else
-parameter interrupt_cause_t implemented_interrupt[] = {
+const interrupt_cause_t implemented_interrupt[] = {
 `endif
     M_SOFTWARE_INTR,
     M_TIMER_INTR,
@@ -107,7 +107,7 @@ parameter interrupt_cause_t implemented_interrupt[] = {
 `ifdef DSIM
 exception_cause_t implemented_exception[] = {
 `else
-parameter exception_cause_t implemented_exception[] = {
+const exception_cause_t implemented_exception[] = {
 `endif
     INSTRUCTION_ACCESS_FAULT,
     ILLEGAL_INSTRUCTION,

--- a/target/rv32imcb/riscv_core_setting.sv
+++ b/target/rv32imcb/riscv_core_setting.sv
@@ -71,7 +71,7 @@ parameter int NUM_HARTS = 1;
 `ifdef DSIM
 privileged_reg_t implemented_csr[] = {
 `else
-parameter privileged_reg_t implemented_csr[] = {
+const privileged_reg_t implemented_csr[] = {
 `endif
     // Machine mode mode CSR
     MVENDORID,  // Vendor ID
@@ -97,7 +97,7 @@ parameter privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 interrupt_cause_t implemented_interrupt[] = {
 `else
-parameter interrupt_cause_t implemented_interrupt[] = {
+const interrupt_cause_t implemented_interrupt[] = {
 `endif
     M_SOFTWARE_INTR,
     M_TIMER_INTR,
@@ -107,7 +107,7 @@ parameter interrupt_cause_t implemented_interrupt[] = {
 `ifdef DSIM
 exception_cause_t implemented_exception[] = {
 `else
-parameter exception_cause_t implemented_exception[] = {
+const exception_cause_t implemented_exception[] = {
 `endif
     INSTRUCTION_ACCESS_FAULT,
     ILLEGAL_INSTRUCTION,

--- a/target/rv64gc/riscv_core_setting.sv
+++ b/target/rv64gc/riscv_core_setting.sv
@@ -71,7 +71,7 @@ parameter int NUM_HARTS = 1;
 `ifdef DSIM
 privileged_reg_t implemented_csr[] = {
 `else
-parameter privileged_reg_t implemented_csr[] = {
+const privileged_reg_t implemented_csr[] = {
 `endif
     // User mode CSR
     USTATUS,    // User status
@@ -123,7 +123,7 @@ parameter privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 interrupt_cause_t implemented_interrupt[] = {
 `else
-parameter interrupt_cause_t implemented_interrupt[] = {
+const interrupt_cause_t implemented_interrupt[] = {
 `endif
     U_SOFTWARE_INTR,
     S_SOFTWARE_INTR,
@@ -139,7 +139,7 @@ parameter interrupt_cause_t implemented_interrupt[] = {
 `ifdef DSIM
 exception_cause_t implemented_exception[] = {
 `else
-parameter exception_cause_t implemented_exception[] = {
+const exception_cause_t implemented_exception[] = {
 `endif
     INSTRUCTION_ACCESS_FAULT,
     ILLEGAL_INSTRUCTION,

--- a/target/rv64gcv/riscv_core_setting.sv
+++ b/target/rv64gcv/riscv_core_setting.sv
@@ -70,7 +70,7 @@ parameter int NUM_HARTS = 1;
 `ifdef DSIM
 privileged_reg_t implemented_csr[] = {
 `else
-parameter privileged_reg_t implemented_csr[] = {
+const privileged_reg_t implemented_csr[] = {
 `endif
     // User mode CSR
     USTATUS,    // User status
@@ -122,7 +122,7 @@ parameter privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 interrupt_cause_t implemented_interrupt[] = {
 `else
-parameter interrupt_cause_t implemented_interrupt[] = {
+const interrupt_cause_t implemented_interrupt[] = {
 `endif
     U_SOFTWARE_INTR,
     S_SOFTWARE_INTR,
@@ -138,7 +138,7 @@ parameter interrupt_cause_t implemented_interrupt[] = {
 `ifdef DSIM
 exception_cause_t implemented_exception[] = {
 `else
-parameter exception_cause_t implemented_exception[] = {
+const exception_cause_t implemented_exception[] = {
 `endif
     INSTRUCTION_ACCESS_FAULT,
     ILLEGAL_INSTRUCTION,

--- a/target/rv64imc/riscv_core_setting.sv
+++ b/target/rv64imc/riscv_core_setting.sv
@@ -71,7 +71,7 @@ parameter int NUM_HARTS = 1;
 `ifdef DSIM
 privileged_reg_t implemented_csr[] = {
 `else
-parameter privileged_reg_t implemented_csr[] = {
+const privileged_reg_t implemented_csr[] = {
 `endif
     // Machine mode mode CSR
     MVENDORID,  // Vendor ID
@@ -97,7 +97,7 @@ parameter privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 interrupt_cause_t implemented_interrupt[] = {
 `else
-parameter interrupt_cause_t implemented_interrupt[] = {
+const interrupt_cause_t implemented_interrupt[] = {
 `endif
     M_SOFTWARE_INTR,
     M_TIMER_INTR,
@@ -107,7 +107,7 @@ parameter interrupt_cause_t implemented_interrupt[] = {
 `ifdef DSIM
 exception_cause_t implemented_exception[] = {
 `else
-parameter exception_cause_t implemented_exception[] = {
+const exception_cause_t implemented_exception[] = {
 `endif
     INSTRUCTION_ACCESS_FAULT,
     ILLEGAL_INSTRUCTION,


### PR DESCRIPTION
Parameters should be constant at elaboration time. Creating parameter of dynamic array type (which main idea it to be dynamic at runtime) is not clearly defined as legal by LRM. 

Please change it to a const array - it should express expected behaviour better.
