### PR TITLE
[pmp] Relative addressing scheme to configure pmpaddr

### DIFF
--- a/src/riscv_asm_program_gen.sv
+++ b/src/riscv_asm_program_gen.sv
@@ -697,7 +697,7 @@ class riscv_asm_program_gen extends uvm_object;
     string instr[$];
     if (riscv_instr_pkg::support_pmp) begin
       cfg.pmp_cfg.setup_pmp();
-      cfg.pmp_cfg.gen_pmp_instr(instr, cfg.scratch_reg);
+      cfg.pmp_cfg.gen_pmp_instr({cfg.scratch_reg, cfg.gpr[0]}, instr);
       gen_section(get_label("pmp_setup", hart), instr);
     end
   endfunction

--- a/src/riscv_instr_gen_config.sv
+++ b/src/riscv_instr_gen_config.sv
@@ -77,7 +77,8 @@ class riscv_instr_gen_config extends uvm_object;
   // Reserved register
   // Reserved for various hardcoded routines
   rand riscv_reg_t       gpr[4];
-  // Used by any DCSR operations inside of the debug rom
+  // Used by any DCSR operations inside of the debug rom.
+  // Also used by the PMP generation.
   rand riscv_reg_t       scratch_reg;
   // Use a random register for stack pointer/thread pointer
   rand riscv_reg_t       sp;

--- a/src/riscv_instr_pkg.sv
+++ b/src/riscv_instr_pkg.sv
@@ -1051,9 +1051,9 @@ package riscv_instr_pkg;
     rand bit                   x;
     rand bit                   w;
     rand bit                   r;
-    // RV32: addr is the top 32 bits of a 34 bit PMP address
-    // RV64: addr is the top 54 bits of a 56 bit PMP address
-    rand bit [XLEN - 1 : 0]    addr;
+    // RV32: the pmpaddr is the top 32 bits of a 34 bit PMP address
+    // RV64: the pmpaddr is the top 54 bits of a 56 bit PMP address
+    rand bit [XLEN - 1 : 0]    offset;
   } pmp_cfg_reg_t;
 
   function automatic string hart_prefix(int hart = 0);

--- a/src/riscv_pmp_cfg.sv
+++ b/src/riscv_pmp_cfg.sv
@@ -28,28 +28,13 @@ class riscv_pmp_cfg extends uvm_object;
   // pmp CSR configurations
   rand pmp_cfg_reg_t pmp_cfg[];
 
-  // PMP maximum address - used to set defaults
-  bit [XLEN - 1 : 0] pmp_max_address = {XLEN{1'b1}};
-
-  // As supporting PMP will cause the major initialization and exception handling
-  // routines to all be generated before the <main> section of the output program,
-  // this option enables/disables automatic creation of a PMP "safe region"
-  // that enables all accesses to these subroutines without throwing any PMP faults.
-  // pmp_min_addr is used as the configuration address for this region.
-  // Setting this will write the configuration:
-  //  { L:0, A:TOR, X:1, W:1, R:1, ADDR:<pmp_min_address>  }
-  // to the pmpcfg0 and pmpaddr0 CSRs and will cause any explicitly declared
-  // configuration for pmp_region_0 from the command line to be ignored.
-  bit pmp_enable_safe_region = 1'b0;
-
-  // PMP "minimum" address - the address written to pmpaddr0
-  // to create a "safe region", which contains important setup code,
-  // and cannot throw a PMP fault.
-  // This should be manually set to just after the location of the <main>
-  // section of the program to allow all initialization routines to not be
-  // interrupted by PMP faults.
-  // This value will default to 0, and will only be valid if pmp_enable_safe_region is set.
-  bit [XLEN - 1 : 0] pmp_min_address = 0;
+  // This value is the address offset between the minimum and maximum pmpaddr
+  // CSR values.
+  // As pmpaddr0 will be set to the address of the <main> label, the address stored
+  // in pmpaddr0 added to this pmp_max_offset value will give the upper bound of the
+  // address range covered by the PMP address range.
+  // Can be manually configured from the command line.
+  bit [XLEN - 1 : 0] pmp_max_offset = {XLEN{1'b1}};
 
   // used to parse addr_mode configuration from cmdline
   typedef uvm_enum_wrapper#(pmp_addr_mode_t) addr_mode_wrapper;
@@ -58,8 +43,7 @@ class riscv_pmp_cfg extends uvm_object;
   `uvm_object_utils_begin(riscv_pmp_cfg)
     `uvm_field_int(pmp_num_regions, UVM_DEFAULT)
     `uvm_field_int(pmp_granularity, UVM_DEFAULT)
-    `uvm_field_int(pmp_max_address, UVM_DEFAULT)
-    `uvm_field_int(pmp_min_address, UVM_DEFAULT)
+    `uvm_field_int(pmp_max_offset, UVM_DEFAULT)
   `uvm_object_utils_end
 
   // constraints
@@ -82,21 +66,20 @@ class riscv_pmp_cfg extends uvm_object;
     }
   }
 
+  // TODO: add feature to disable overlapping address ranges
+  constraint addr_range_c {
+  }
+
   function new(string name = "");
     string s;
     super.new(name);
     inst = uvm_cmdline_processor::get_inst();
     get_bool_arg_value("+pmp_randomize=", pmp_randomize);
-    get_bool_arg_value("+pmp_enable_safe_region=", pmp_enable_safe_region);
     get_int_arg_value("+pmp_granularity=", pmp_granularity);
     get_int_arg_value("+pmp_num_regions=", pmp_num_regions);
-    get_hex_arg_value("+pmp_min_address=", pmp_min_address);
-    get_hex_arg_value("+pmp_max_address=", pmp_max_address);
+    get_hex_arg_value("+pmp_max_offset=", pmp_max_offset);
+    `uvm_info(`gfn, $sformatf("pmp max offset: 0x%0x", pmp_max_offset), UVM_LOW)
     pmp_cfg = new[pmp_num_regions];
-    // As per privileged spec, the top 10 bits of a rv64 PMP address are all 0.
-    if (XLEN == 64) begin
-      pmp_max_address[XLEN - 1 : XLEN - 11] = 10'b0;
-    end
   endfunction
 
   function void initialize(bit require_signature_addr);
@@ -113,25 +96,22 @@ class riscv_pmp_cfg extends uvm_object;
   endfunction
 
   function void set_defaults();
+    `uvm_info(`gfn, $sformatf("MAX OFFSET: 0x%0x", pmp_max_offset), UVM_LOW)
     foreach(pmp_cfg[i]) begin
-      pmp_cfg[i].l    = 1'b0;
-      pmp_cfg[i].a    = TOR;
-      pmp_cfg[i].x    = 1'b1;
-      pmp_cfg[i].w    = 1'b1;
-      pmp_cfg[i].r    = 1'b1;
-      pmp_cfg[i].addr = assign_default_addr(pmp_num_regions, i);
+      pmp_cfg[i].l      = 1'b0;
+      pmp_cfg[i].a      = TOR;
+      pmp_cfg[i].x      = 1'b1;
+      pmp_cfg[i].w      = 1'b1;
+      pmp_cfg[i].r      = 1'b1;
+      pmp_cfg[i].offset = assign_default_addr_offset(pmp_num_regions, i);
     end
   endfunction
 
-  function bit [XLEN - 1 : 0] assign_default_addr(int num_regions, int index);
-    bit [XLEN - 1 : 0] total_addr_space, offset;
-    if (pmp_enable_safe_region) begin
-      total_addr_space = pmp_max_address - pmp_min_address;
-      offset = total_addr_space / (num_regions - 1) * index;
-      return pmp_min_address + offset;
-    end else begin
-      return pmp_max_address / num_regions * (index + 1);
-    end
+  function bit [XLEN - 1 : 0] assign_default_addr_offset(int num_regions, int index);
+    bit [XLEN - 1 : 0] offset;
+    offset = pmp_max_offset / (num_regions - 1);
+    offset = offset * index;
+    return offset;
   endfunction
 
   function void setup_pmp();
@@ -177,7 +157,7 @@ class riscv_pmp_cfg extends uvm_object;
         "ADDR": begin
           // Don't have to convert address to "PMP format" here,
           // since it must be masked off in hardware
-          pmp_cfg_reg.addr = format_addr(field_val.atohex());
+          pmp_cfg_reg.offset = format_addr(field_val.atohex());
         end
         default: begin
           `uvm_fatal(`gfn, $sformatf("%s, Invalid PMP configuration field name!", field_val))
@@ -214,7 +194,7 @@ class riscv_pmp_cfg extends uvm_object;
   // Since either 4 (in rv32) or 8 (in rv64) PMP configuration registers fit into one physical
   // CSR, this function waits until it has reached this maximum to write to the physical CSR to
   // save some extraneous instructions from being performed.
-  function void gen_pmp_instr(ref string instr[$], riscv_reg_t scratch_reg);
+  function void gen_pmp_instr(riscv_reg_t scratch_reg[2], ref string instr[$]);
     int cfg_per_csr = XLEN / 8;
     bit [XLEN - 1 : 0] pmp_word;
     bit [XLEN - 1 : 0] cfg_bitmask;
@@ -225,34 +205,48 @@ class riscv_pmp_cfg extends uvm_object;
     foreach (pmp_cfg[i]) begin
       // TODO(udinator) condense this calculations if possible
       pmp_id = i / cfg_per_csr;
-      if (pmp_enable_safe_region && i == 0) begin
+      if (i == 0) begin
         cfg_byte = {1'b0, pmp_cfg[i].zero, TOR, 1'b1, 1'b1, 1'b1};
       end else begin
         cfg_byte = {pmp_cfg[i].l, pmp_cfg[i].zero, pmp_cfg[i].a,
                     pmp_cfg[i].x, pmp_cfg[i].w, pmp_cfg[i].r};
       end
       `uvm_info(`gfn, $sformatf("cfg_byte: 0x%0x", cfg_byte), UVM_DEBUG)
+      // First write to the appropriate pmpaddr CSR
       cfg_bitmask = cfg_byte << ((i % cfg_per_csr) * 8);
       `uvm_info(`gfn, $sformatf("cfg_bitmask: 0x%0x", cfg_bitmask), UVM_DEBUG)
       pmp_word = pmp_word | cfg_bitmask;
       `uvm_info(`gfn, $sformatf("pmp_word: 0x%0x", pmp_word), UVM_DEBUG)
       cfg_bitmask = 0;
-      instr.push_back($sformatf("li x%0d, 0x%0x", scratch_reg, pmp_cfg[i].addr));
-      instr.push_back($sformatf("csrw 0x%0x, x%0d", base_pmp_addr + i, scratch_reg));
-      `uvm_info(`gfn, $sformatf("pmp_addr_%d: 0x%0x", i, pmp_cfg[i].addr), UVM_DEBUG)
-      // short circuit if end of list
+      if (i == 0) begin
+        // load the address of the <main> section into pmpaddr0
+        instr.push_back($sformatf("la x%0d, main", scratch_reg[0]));
+        instr.push_back($sformatf("csrw 0x%0x, x%0d", base_pmp_addr + i, scratch_reg[0]));
+        `uvm_info(`gfn, "Loaded the address of <main> section into pmpaddr0", UVM_LOW)
+      end else begin
+        // Add the offset to the base address to get the other pmpaddr values
+        instr.push_back($sformatf("csrr x%0d, 0x%0x", scratch_reg[0], base_pmp_addr));
+        instr.push_back($sformatf("li x%0d, 0x%0x", scratch_reg[1], pmp_cfg[i].offset));
+        instr.push_back($sformatf("add x%0d, x%0d, x%0d",
+                                  scratch_reg[0], scratch_reg[0], scratch_reg[1]));
+        instr.push_back($sformatf("csrw 0x%0x, x%0d", base_pmp_addr + i, scratch_reg[0]));
+        `uvm_info(`gfn, $sformatf("Offset of pmp_addr_%d from pmpaddr0: 0x%0x",
+                                  i, pmp_cfg[i].offset), UVM_LOW)
+      end
+      // Now, check if we have to write to the appropriate pmpcfg CSR.
+        // Short circuit if we reach the end of the list
       if (i == pmp_cfg.size() - 1) begin
-        instr.push_back($sformatf("li x%0d, 0x%0x", scratch_reg, pmp_word));
+        instr.push_back($sformatf("li x%0d, 0x%0x", scratch_reg[0], pmp_word));
         instr.push_back($sformatf("csrw 0x%0x, x%0d",
                                   base_pmpcfg_addr + pmp_id,
-                                  scratch_reg));
+                                  scratch_reg[0]));
         return;
       end else if ((i + 1) % cfg_per_csr == 0) begin
         // if we've filled up pmp_word, write to the corresponding CSR
-        instr.push_back($sformatf("li x%0d, 0x%0x", scratch_reg, pmp_word));
+        instr.push_back($sformatf("li x%0d, 0x%0x", scratch_reg[0], pmp_word));
         instr.push_back($sformatf("csrw 0x%0x, x%0d",
                                   base_pmpcfg_addr + pmp_id,
-                                  scratch_reg));
+                                  scratch_reg[0]));
         pmp_word = 0;
       end
     end


### PR DESCRIPTION
Load the address of `<main>` section into `pmpaddr0` CSR, and use an offset scheme to configure all other enabled `pmpaddr` CSRs relative to the first one.