### PR TITLE
Add config knob to add 4 to mepc

### DIFF
--- a/src/riscv_asm_program_gen.sv
+++ b/src/riscv_asm_program_gen.sv
@@ -601,7 +601,7 @@ class riscv_asm_program_gen extends uvm_object;
 
   virtual function void pre_enter_privileged_mode(int hart);
     string instr[];
-	string str[$];    
+	string str[$];
 	// Setup kerenal stack pointer
 	str = {$sformatf("la x%0d, %0skernel_stack_end", cfg.tp, hart_prefix(hart))};
 	gen_section(get_label("kernel_sp", hart), str);
@@ -1046,6 +1046,13 @@ class riscv_asm_program_gen extends uvm_object;
     string instr[$];
     gen_signature_handshake(instr, CORE_STATUS, INSTR_FAULT_EXCEPTION);
     gen_signature_handshake(.instr(instr), .signature_type(WRITE_CSR), .csr(MCAUSE));
+    if (cfg.write_epc_in_exception_handler) begin
+      instr = {instr,
+              $sformatf("csrr  x%0d, mepc", cfg.gpr[0]),
+              $sformatf("addi  x%0d, x%0d, 4", cfg.gpr[0], cfg.gpr[0]),
+              $sformatf("csrw  mepc, x%0d", cfg.gpr[0])
+      };
+    end
     pop_gpr_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr);
     instr.push_back("mret");
     gen_section(get_label("instr_fault_handler", hart), instr);
@@ -1056,6 +1063,13 @@ class riscv_asm_program_gen extends uvm_object;
     string instr[$];
     gen_signature_handshake(instr, CORE_STATUS, LOAD_FAULT_EXCEPTION);
     gen_signature_handshake(.instr(instr), .signature_type(WRITE_CSR), .csr(MCAUSE));
+    if (cfg.write_epc_in_exception_handler) begin
+      instr = {instr,
+              $sformatf("csrr  x%0d, mepc", cfg.gpr[0]),
+              $sformatf("addi  x%0d, x%0d, 4", cfg.gpr[0], cfg.gpr[0]),
+              $sformatf("csrw  mepc, x%0d", cfg.gpr[0])
+      };
+    end
     pop_gpr_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr);
     instr.push_back("mret");
     gen_section(get_label("load_fault_handler", hart), instr);
@@ -1066,6 +1080,13 @@ class riscv_asm_program_gen extends uvm_object;
     string instr[$];
     gen_signature_handshake(instr, CORE_STATUS, STORE_FAULT_EXCEPTION);
     gen_signature_handshake(.instr(instr), .signature_type(WRITE_CSR), .csr(MCAUSE));
+    if (cfg.write_epc_in_exception_handler) begin
+      instr = {instr,
+              $sformatf("csrr  x%0d, mepc", cfg.gpr[0]),
+              $sformatf("addi  x%0d, x%0d, 4", cfg.gpr[0], cfg.gpr[0]),
+              $sformatf("csrw  mepc, x%0d", cfg.gpr[0])
+      };
+    end
     pop_gpr_from_kernel_stack(MSTATUS, MSCRATCH, cfg.mstatus_mprv, cfg.sp, cfg.tp, instr);
     instr.push_back("mret");
     gen_section(get_label("store_fault_handler", hart), instr);

--- a/src/riscv_instr_gen_config.sv
+++ b/src/riscv_instr_gen_config.sv
@@ -174,6 +174,8 @@ class riscv_instr_gen_config extends uvm_object;
   // Enable interrupt bit in MSTATUS (MIE, SIE, UIE)
   bit                    enable_interrupt;
   bit                    enable_nested_interrupt;
+  // Enables manual override of MEPC in various exception handlers
+  bit                    write_epc_in_exception_handler;
   // We need a separate control knob for enabling timer interrupts, as Spike
   // throws an exception if xIE.xTIE is enabled
   bit                    enable_timer_irq;
@@ -456,6 +458,7 @@ class riscv_instr_gen_config extends uvm_object;
     `uvm_field_string(boot_mode_opts, UVM_DEFAULT)
     `uvm_field_int(enable_page_table_exception, UVM_DEFAULT)
     `uvm_field_int(no_directed_instr, UVM_DEFAULT)
+    `uvm_field_int(write_epc_in_exception_handler, UVM_DEFAULT)
     `uvm_field_int(enable_interrupt, UVM_DEFAULT)
     `uvm_field_int(enable_timer_irq, UVM_DEFAULT)
     `uvm_field_int(bare_program_mode, UVM_DEFAULT)
@@ -497,6 +500,7 @@ class riscv_instr_gen_config extends uvm_object;
     inst = uvm_cmdline_processor::get_inst();
     get_int_arg_value("+num_of_tests=", num_of_tests);
     get_int_arg_value("+enable_page_table_exception=", enable_page_table_exception);
+    get_bool_arg_value("+write_epc_in_exception_handler=", write_epc_in_exception_handler);
     get_bool_arg_value("+enable_interrupt=", enable_interrupt);
     get_bool_arg_value("+enable_nested_interrupt=", enable_nested_interrupt);
     get_bool_arg_value("+enable_timer_irq=", enable_timer_irq);


### PR DESCRIPTION
For situations like PMP, we need to add 4 to MEPC during all relevant exception handlers, otherwise it will cause an infinite loop of trying to execute the same instruction, repeating the same PMP fault over and over again.