### PR TITLE
specify physical pmp addresses from cmdline

### DIFF
--- a/src/riscv_instr_pkg.sv
+++ b/src/riscv_instr_pkg.sv
@@ -1054,6 +1054,9 @@ package riscv_instr_pkg;
     bit                   r;
     // RV32: the pmpaddr is the top 32 bits of a 34 bit PMP address
     // RV64: the pmpaddr is the top 54 bits of a 56 bit PMP address
+    bit [XLEN - 1 : 0]    addr;
+    // The offset from the address of <main> - automatically populated by the
+    // PMP generation routine.
     bit [XLEN - 1 : 0]    offset;
 `else
   typedef struct{
@@ -1065,6 +1068,9 @@ package riscv_instr_pkg;
     rand bit                   r;
     // RV32: the pmpaddr is the top 32 bits of a 34 bit PMP address
     // RV64: the pmpaddr is the top 54 bits of a 56 bit PMP address
+    bit [XLEN - 1 : 0]    addr;
+    // The offset from the address of <main> - automatically populated by the
+    // PMP generation routine.
     rand bit [XLEN - 1 : 0]    offset;
 `endif
   } pmp_cfg_reg_t;


### PR DESCRIPTION
This is a relatively straightforward PR with the initial steps to convert from passing in a "max_offset" from the command line (which is pretty unintuitive from the user perspective) to passing in a maximum limit address, to eventually being able to assign code sections to pmp regions from the command line.

For now, we take the first step of adding back functionality to specify a physical address from the cmdline separately from the default assigned offset - if specified, this address will take priority over the offset when configuring pmp CSRs.