### PR TITLE
fix bug with compressed ebreak generation

### DIFF
--- a/src/isa/riscv_instr.sv
+++ b/src/isa/riscv_instr.sv
@@ -181,7 +181,8 @@ class riscv_instr extends uvm_object;
     if (!cfg.no_ebreak) begin
       basic_instr = {basic_instr, EBREAK};
       foreach (riscv_instr_pkg::supported_isa[i]) begin
-        if (RV32C inside {riscv_instr_pkg::supported_isa[i]}) begin
+        if (RV32C inside {riscv_instr_pkg::supported_isa[i]} &&
+            !cfg.disable_compressed_instr) begin
           basic_instr = {basic_instr, C_EBREAK};
           break;
         end


### PR DESCRIPTION
currently, the combination of `+no_ebreak=0` and `+disable_compressed_instr=1` will incorrectly generate compressed ebreak instructions - this PR fixes that issue.