### PR TITLE
Add --seed_start argument and tidy up seed handling

### DIFF
--- a/run.py
+++ b/run.py
@@ -18,6 +18,7 @@ Regression script for RISC-V random instruction generator
 
 import argparse
 import os
+import random
 import re
 import sys
 import logging
@@ -32,6 +33,39 @@ from scripts.instr_trace_compare import *
 from types import SimpleNamespace
 
 LOGGER = logging.getLogger()
+
+
+class SeedGen:
+  '''An object that will generate a pseudo-random seed for test iterations'''
+  def __init__(self, start_seed, fixed_seed, seed_yaml):
+    # These checks are performed with proper error messages at argument parsing
+    # time, but it can't hurt to do a belt-and-braces check here too.
+    assert fixed_seed is None or start_seed is None
+
+    self.fixed_seed = fixed_seed
+    self.start_seed = start_seed
+    self.rerun_seed = {} if seed_yaml is None else read_yaml(seed_yaml)
+
+  def get(self, test_id, test_iter):
+    '''Get the seed to use for the given test and iteration'''
+
+    if test_id in self.rerun_seed:
+      # Note that test_id includes the iteration index (well, the batch index,
+      # at any rate), so this makes sense even if test_iter > 0.
+      return self.rerun_seed[test_id]
+
+    if self.fixed_seed is not None:
+      # Checked at argument parsing time
+      assert test_iter == 0
+      return self.fixed_seed
+
+    if self.start_seed is not None:
+      return self.start_seed + test_iter
+
+    # If the user didn't specify seeds in some way, we generate a random seed
+    # every time
+    return random.getrandbits(31)
+
 
 def get_generator_cmd(simulator, simulator_yaml, cov, exp, debug_cmd):
   """ Setup the compile and simulation command for the generator
@@ -186,7 +220,7 @@ def run_csr_test(cmd_list, cwd, csr_file, isa, iterations, lsf_cmd,
     run_cmd(cmd, timeout_s, debug_cmd = debug_cmd)
 
 
-def do_simulate(sim_cmd, test_list, cwd, sim_opts, seed_yaml, seed, csr_file,
+def do_simulate(sim_cmd, test_list, cwd, sim_opts, seed_gen, csr_file,
                 isa, end_signature_addr, lsf_cmd, timeout_s, log_suffix,
                 batch_size, output_dir, verbose, check_return_code, debug_cmd):
   """Run  the instruction generator
@@ -196,8 +230,7 @@ def do_simulate(sim_cmd, test_list, cwd, sim_opts, seed_yaml, seed, csr_file,
     test_list             : List of assembly programs to be compiled
     cwd                   : Filesystem path to RISCV-DV repo
     sim_opts              : Simulation options for the generator
-    seed_yaml             : Seed specification from a prior regression
-    seed                  : Seed to the instruction generator
+    seed_gen              : A SeedGen seed generator
     csr_file              : YAML file containing description of all CSRs
     isa                   : Processor supported ISA subset
     end_signature_addr    : Address that tests will write pass/fail signature to at end of test
@@ -213,9 +246,7 @@ def do_simulate(sim_cmd, test_list, cwd, sim_opts, seed_yaml, seed, csr_file,
   sim_cmd = re.sub("<out>", os.path.abspath(output_dir), sim_cmd)
   sim_cmd = re.sub("<cwd>", cwd, sim_cmd)
   sim_cmd = re.sub("<sim_opts>", sim_opts, sim_cmd)
-  rerun_seed = {}
-  if seed_yaml:
-    rerun_seed = read_yaml(seed_yaml)
+
   logging.info("Running RISC-V instruction generator")
   sim_seed = {}
   for test in test_list:
@@ -233,10 +264,7 @@ def do_simulate(sim_cmd, test_list, cwd, sim_opts, seed_yaml, seed, csr_file,
         logging.info("Running %s with %0d batches" % (test['test'], batch_cnt))
         for i in range(0, batch_cnt):
           test_id = '%0s_%0d' % (test['test'], i)
-          if test_id in rerun_seed:
-            rand_seed = rerun_seed[test_id]
-          else:
-            rand_seed = get_seed(seed)
+          rand_seed = seed_gen.get(test_id, i * batch_cnt)
           if i < batch_cnt - 1:
             test_cnt = batch_size
           else:
@@ -270,18 +298,15 @@ def do_simulate(sim_cmd, test_list, cwd, sim_opts, seed_yaml, seed, csr_file,
                      debug_cmd = debug_cmd)
 
 
-def gen(test_list, cfg, output_dir, cwd):
+def gen(test_list, argv, output_dir, cwd):
   """Run the instruction generator
 
   Args:
     test_list             : List of assembly programs to be compiled
-    cfg                   : Loaded configuration dictionary.
+    argv                  : Configuration arguments
     output_dir            : Output directory of the ELF files
     cwd                   : Filesystem path to RISCV-DV repo
   """
-  # Convert key dictionary to argv variable
-  argv= SimpleNamespace(**cfg)
-
   check_return_code = True
   if argv.simulator == "ius":
     # Incisive return non-zero return code even test passes
@@ -304,7 +329,8 @@ def gen(test_list, cfg, output_dir, cwd):
                argv.cmp_opts, output_dir, argv.debug, argv.lsf_cmd)
   # Run the instruction generator
   if not argv.co:
-    do_simulate(sim_cmd, test_list, cwd, argv.sim_opts, argv.seed_yaml, argv.seed, argv.csr_yaml,
+    seed_gen = SeedGen(argv.start_seed, argv.seed, argv.seed_yaml)
+    do_simulate(sim_cmd, test_list, cwd, argv.sim_opts, seed_gen, argv.csr_yaml,
                 argv.isa, argv.end_signature_addr, argv.lsf_cmd, argv.gen_timeout, argv.log_suffix,
                 argv.batch_size, output_dir, argv.verbose, check_return_code, argv.debug)
 
@@ -644,7 +670,20 @@ def save_regr_report(report):
   logging.info("ISS regression report is saved to %s" % report)
 
 
-def setup_parser():
+def read_seed(arg):
+    '''Read --seed or --seed_start'''
+    try:
+        seed = int(arg)
+        if seed < 0:
+            raise ValueError('bad seed')
+        return seed
+
+    except ValueError:
+        raise argparse.ArgumentTypeError('Bad seed ({}): '
+                                         'must be a non-negative integer.'
+                                         .format(arg))
+
+def parse_args(cwd):
   """Create a command line parser.
 
   Returns: The created parser.
@@ -661,8 +700,6 @@ def setup_parser():
                       help="Regression testlist", dest="testlist")
   parser.add_argument("-tn", "--test", type=str, default="all",
                       help="Test name, 'all' means all tests in the list", dest="test")
-  parser.add_argument("--seed", type=int, default=-1,
-                      help="Randomization seed, default -1 means random seed")
   parser.add_argument("-i", "--iterations", type=int, default=0,
                       help="Override the iteration count in the test list", dest="iterations")
   parser.add_argument("-si", "--simulator", type=str, default="vcs",
@@ -706,9 +743,6 @@ def setup_parser():
                       help="RTL simulator setting YAML")
   parser.add_argument("--csr_yaml", type=str, default="",
                       help="CSR description file")
-  parser.add_argument("--seed_yaml", type=str, default="",
-                      help="Rerun the generator with the seed specification \
-                            from a prior regression")
   parser.add_argument("-ct", "--custom_target", type=str, default="",
                       help="Directory name of the custom target")
   parser.add_argument("-cs", "--core_setting_dir", type=str, default="",
@@ -735,7 +769,47 @@ def setup_parser():
                       help="Run verilog style check")
   parser.add_argument("-d", "--debug", type=str, default="",
                       help="Generate debug command log file")
-  return parser
+
+  rsg = parser.add_argument_group('Random seeds',
+                                  'To control random seeds, use at most one '
+                                  'of the --start_seed, --seed or --seed_yaml '
+                                  'arguments. Since the latter two only give '
+                                  'a single seed for each test, they imply '
+                                  '--iterations=1.')
+
+  rsg.add_argument("--start_seed", type=read_seed,
+                   help=("Randomization seed to use for first iteration of "
+                         "each test. Subsequent iterations use seeds "
+                         "counting up from there. Cannot be used with "
+                         "--seed or --seed_yaml."))
+  rsg.add_argument("--seed", type=read_seed,
+                   help=("Randomization seed to use for each test. "
+                         "Implies --iterations=1. Cannot be used with "
+                         "--start_seed or --seed_yaml."))
+  rsg.add_argument("--seed_yaml", type=str,
+                   help=("Rerun the generator with the seed specification "
+                         "from a prior regression. Implies --iterations=1. "
+                         "Cannot be used with --start_seed or --seed."))
+
+  args = parser.parse_args()
+
+  if args.seed is not None and args.start_seed is not None:
+    logging.error('--start_seed and --seed are mutually exclusive.')
+    sys.exit(RET_FAIL)
+
+  if args.seed is not None:
+    if args.iterations == 0:
+      args.iterations = 1
+    elif args.iterations > 1:
+      logging.error('--seed is incompatible with setting --iterations '
+                    'greater than 1.')
+      sys.exit(RET_FAIL)
+
+  # We've parsed all the arguments from the command line; default values
+  # can be set in the config file. Read that here.
+  load_config(args, cwd)
+
+  return args
 
 
 def load_config(args, cwd):
@@ -804,21 +878,17 @@ def load_config(args, cwd):
         sys.exit("mabi and isa must be specified for custom target %0s" % args.custom_target)
     if not args.testlist:
       args.testlist = args.custom_target + "/testlist.yaml"
-  # Create loaded configuration dictionary.
-  cfg = vars(args)
-  return cfg
 
 
 def main():
   """This is the main entry point."""
   try:
-    parser = setup_parser()
-    args = parser.parse_args()
     cwd = os.path.dirname(os.path.realpath(__file__))
     os.environ["RISCV_DV_ROOT"] = cwd
+
+    args = parse_args(cwd)
     setup_logging(args.verbose)
-    # Load configuration from the command line and the configuration file.
-    cfg = load_config(args, cwd)
+
     # Create output directory
     output_dir = create_output(args.o, args.noclean)
 
@@ -941,7 +1011,7 @@ def main():
                 sys.exit(RET_FAIL)
 
       # Run remaining tests using the instruction generator
-      gen(matched_list, cfg, output_dir, cwd)
+      gen(matched_list, args, output_dir, cwd)
 
     if not args.co:
       # Compile the assembly program to ELF, convert to plain binary

--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -85,20 +85,6 @@ def get_env_var(var, debug_cmd = None):
   return val
 
 
-def get_seed(seed):
-  """Get the seed to run the generator
-
-  Args:
-    seed : input seed
-
-  Returns:
-    seed to run instruction generator
-  """
-  if seed >= 0:
-    return seed
-  return random.getrandbits(31)
-
-
 def run_cmd(cmd, timeout_s = 999, exit_on_error = 1, check_return_code = True, debug_cmd = None):
   """Run a command and return output
 


### PR DESCRIPTION
*Note: I've edited this summary to match the version pushed up as `5dbfc25`.*

The `--seed_start` argument allows you to say "Please use the following
seed for the first iteration of each test. If you run more iterations
than one, increment the seed accordingly".

The idea is that some top-level program (for example Ibex's core_ibex
UVM test code) can pick a seed, possibly randomly, and then run many
tests using the same seeds for test generation (here) and test
execution (passed to the simulator that runs them).

We could implement that by generating a YAML file each time and
passing it with `--seed_yaml`, but that seems unnecessarily complicated.

While touching the seed handling code, I've also added checks for
various silly combinations of arguments that used to be possible.

  - If you specify `--seed` and `--iterations 10`, you'll now get an
    error. This is probably sensible because you're asking for 10
    identical tests, which is unlikely to be what you want.

  - If you specify `--seed` and don't specify `--iterations`, the
    iteration count is now forced to 1 rather than being read from the
    configuration file. Same reason as above.

The patch also pulls seed handling into a wrapper class (`SeedGen`),
which avoids having to pass yet another argument to `do_simulate`.

It also folds config file parsing into the end of `parse_args` and gets
rid of the call to `var(..)` at the end of `load_config`: we used to
convert from the `args` namespace to a dictionary called `cfg`, and then
promptly converted it back into a namespace. This seems a little
silly, so the patch gets rid of it.

Note: Before and after this patch, test seeds depend on the batch
size. This is because we don't re-seed between tests in a batch. For
example, these two commands will generate different programs:

    ./run.py --iterations=100 --batch-size 5 --seed_start 123
    ./run.py --iterations=100 --batch-size 10 --seed_start 123

It's not *too* bad, because the "test_id" which we use as a key in the
stored list of seeds is actually "test_name + batch index". But you'll
only be able to reproduce a generated test with a high iteration
number if you keep the batch size equal to the last time you ran.

This is easy enough to fix by passing an initial seed as a
plusarg (rather than using -svseed / -sv_seed arguments) and then
reseeding with, say, <seed> + <iteration> between each generated test.
I'll leave this for a later patch.