### PR TITLE
 Move `sext.b/h` bitmanip instructions to ZB_TMP

### DIFF
--- a/src/isa/riscv_b_instr.sv
+++ b/src/isa/riscv_b_instr.sv
@@ -475,9 +475,7 @@ class riscv_b_instr extends riscv_instr;
                }) ||
            (ZBE inside {cfg.enable_bitmanip_groups} && instr_name inside {
                BEXT, BEXTW,
-               BDEP, BDEPW,
-               // TODO, spec 0.92 doesn't categorize these 2 instr in any group, put in ZBE for now
-               SEXT_B, SEXT_H
+               BDEP, BDEPW
                }) ||
            (ZBF inside {cfg.enable_bitmanip_groups} && instr_name inside {BFP, BFPW}) ||
            (ZBC inside {cfg.enable_bitmanip_groups} && instr_name inside {
@@ -492,7 +490,11 @@ class riscv_b_instr extends riscv_instr;
                }) ||
            (ZBT inside {cfg.enable_bitmanip_groups} && instr_name inside {
                CMOV, CMIX,
-               FSL, FSLW, FSR, FSRW, FSRI, FSRIW}));
+               FSL, FSLW, FSR, FSRW, FSRI, FSRIW}) ||
+           // TODO, spec 0.92 doesn't categorize these 2 instr, put them in ZB_TMP #572
+           (ZB_TMP inside {cfg.enable_bitmanip_groups} && instr_name inside {
+               SEXT_B, SEXT_H})
+           );
   endfunction
 
 endclass

--- a/src/riscv_asm_program_gen.sv
+++ b/src/riscv_asm_program_gen.sv
@@ -357,7 +357,7 @@ class riscv_asm_program_gen extends uvm_object;
 
   // Generate the user stack section
   virtual function void gen_stack_section(int hart);
-	string hart_prefix_string = hart_prefix(hart);
+    string hart_prefix_string = hart_prefix(hart);
     if (cfg.use_push_data_section) begin
       instr_stream.push_back($sformatf(".pushsection .%0suser_stack,\"aw\",@progbits;",
                              hart_prefix_string));
@@ -383,7 +383,7 @@ class riscv_asm_program_gen extends uvm_object;
 
   // The kernal stack is used to save user program context before executing exception handling
   virtual function void gen_kernel_stack_section(int hart);
-	string hart_prefix_string = hart_prefix(hart);
+    string hart_prefix_string = hart_prefix(hart);
     if (cfg.use_push_data_section) begin
       instr_stream.push_back($sformatf(".pushsection .%0skernel_stack,\"aw\",@progbits;",
                              hart_prefix_string));

--- a/src/riscv_instr_gen_config.sv
+++ b/src/riscv_instr_gen_config.sv
@@ -245,7 +245,8 @@ class riscv_instr_gen_config extends uvm_object;
   bit                    enable_vector_extension;
   // Bit manipulation extension support
   bit                    enable_b_extension;
-  b_ext_group_t          enable_bitmanip_groups[] = {ZBB, ZBS, ZBP, ZBE, ZBF, ZBC, ZBR, ZBM, ZBT};
+  b_ext_group_t          enable_bitmanip_groups[] = {ZBB, ZBS, ZBP, ZBE, ZBF, ZBC, ZBR, ZBM, ZBT,
+                                                     ZB_TMP};
 
   //-----------------------------------------------------------------------------
   // Command line options for instruction distribution control

--- a/src/riscv_instr_pkg.sv
+++ b/src/riscv_instr_pkg.sv
@@ -1111,7 +1111,8 @@ package riscv_instr_pkg;
     ZBC,
     ZBR,
     ZBM,
-    ZBT
+    ZBT,
+    ZB_TMP // for uncategorized instructions
   } b_ext_group_t;
 
   `VECTOR_INCLUDE("riscv_instr_pkg_inc_variables.sv")


### PR DESCRIPTION
For issue #572
also clean up some tabs