### PR TITLE
Fixes for ML tests

### DIFF
--- a/test/riscv_instr_test_lib.sv
+++ b/test/riscv_instr_test_lib.sv
@@ -47,10 +47,6 @@ class riscv_ml_test extends riscv_instr_base_test;
   `uvm_component_new
 
   virtual function void randomize_cfg();
-    cfg.no_fence = 0;
-    cfg.init_privileged_mode = MACHINE_MODE;
-    cfg.init_privileged_mode.rand_mode(0);
-    cfg.enable_unaligned_load_store = 1'b1;
     cfg.addr_translaction_rnd_order_c.constraint_mode(0);
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
     cfg.addr_translaction_rnd_order_c.constraint_mode(1);


### PR DESCRIPTION
These hardcoded config values are no longer needed for ML testing, they now interfere with randomly generated config parameters and can cause esoteric failures.