### PR TITLE
Add flake8 check for pygen

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+
+# Maximum line length
+max-line-length = 100
+
+ignore =
+  # Ignore unexpected spaces around keyword / parameter equals
+  E251,
+  # Do not complain about line breaks after operators
+  W504

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 dist: xenial
 matrix:
     include:
-        - python: 3.5
-          env: TOX_ENV=py35
         - python: 3.6
           env: TOX_ENV=py36
         - python: 3.7
@@ -15,3 +13,4 @@ install:
 script:
     - sphinx-build -E -W -b linkcheck docs/source build
     - pip uninstall -y riscv-dv
+    - flake8 --show-source pygen/pygen_src/ --config=.flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sphinxcontrib-log-cabinet
 sphinx-issues
 sphinx_rtd_theme
 rst2pdf
+flake8


### PR DESCRIPTION
I add flake8 check for pygen. You can turn on `travis CI` to catch these errors. It currently complains a lot errors:
https://travis-ci.org/github/danghai/riscv-dv/jobs/694103331
You can add `.flake8` if you want to ignore the rules.