### PR TITLE
make <main> 4-byte aligned when enabling PMP

### DIFF
--- a/src/riscv_asm_program_gen.sv
+++ b/src/riscv_asm_program_gen.sv
@@ -78,7 +78,7 @@ class riscv_asm_program_gen extends uvm_object;
       gen_init_section(hart);
       // If PMP is supported, we want to generate the associated trap handlers and the test_done
       // section at the start of the program so we can allow access through the pmpcfg0 CSR
-      if (support_pmp && !cfg.bare_program_mode) begin
+      if (riscv_instr_pkg::support_pmp && !cfg.bare_program_mode) begin
         gen_trap_handlers(hart);
         // Ecall handler
         gen_ecall_handler(hart);
@@ -119,7 +119,7 @@ class riscv_asm_program_gen extends uvm_object;
       instr_stream = {instr_stream, $sformatf("%sj test_done", indent)};
       // Test done section
       // If PMP isn't supported, generate this in the normal location
-      if (hart == 0 & !support_pmp) begin
+      if (hart == 0 & !riscv_instr_pkg::support_pmp) begin
         gen_test_done();
       end
       // Shuffle the sub programs and insert to the instruction stream
@@ -423,7 +423,7 @@ class riscv_asm_program_gen extends uvm_object;
     end
     core_is_initialized();
     gen_dummy_csr_write(); // TODO add a way to disable xStatus read
-    if (support_pmp) begin
+    if (riscv_instr_pkg::support_pmp) begin
       str = {indent, "j main"};
       instr_stream.push_back(str);
     end
@@ -795,7 +795,7 @@ class riscv_asm_program_gen extends uvm_object;
   virtual function void gen_all_trap_handler(int hart);
     string instr[$];
     // If PMP isn't supported, generate the relevant trap handler sections as per usual
-    if (!support_pmp) begin
+    if (!riscv_instr_pkg::support_pmp) begin
       gen_trap_handlers(hart);
       // Ecall handler
       gen_ecall_handler(hart);

--- a/src/riscv_instr_sequence.sv
+++ b/src/riscv_instr_sequence.sv
@@ -275,6 +275,12 @@ class riscv_instr_sequence extends uvm_sequence;
       str = {prefix, instr_stream.instr_list[i].convert2asm()};
       instr_string_list.push_back(str);
     end
+    // If PMP is supported, need to align <main> to a 4-byte boundary.
+    // TODO(udi) - this might interfere with multi-hart programs,
+    //             may need to specifically match hart0.
+    if (riscv_instr_pkg::support_pmp && !uvm_re_match("*main*", label_name)) begin
+      instr_string_list.push_front(".align 2");
+    end
     insert_illegal_hint_instr();
     prefix = format_string($sformatf("%0d:", i), LABEL_STR_LEN);
     if(!is_main_program) begin


### PR DESCRIPTION
When enabling PMP settings, `<main>` section needs to be 4-byte aligned - if it is not there is a chance that the last instruction before `<main>` will cause a PMP exception (if uncompressed).

This PR also scopes all references to `support_pmp` with `riscv_instr_pkg::` just for clarity, this does not functionally change anything.