### PR TITLE
Aldec Riviera-PRO compiler command line arguments modified.

### DIFF
--- a/yaml/simulator.yaml
+++ b/yaml/simulator.yaml
@@ -108,6 +108,7 @@
     cmd:
       - "vlib <out>/work"
       - "vlog -work <out>/work
+        -err VCP2694 W1
         -uvmver 1.2
         +define+UVM_REGEX_NO_DPI
         +incdir+<setting>


### PR DESCRIPTION
Extra switch has been added to the Aldec Riviera-PRO compiler command line arguments to avoid potential compilation problems.