### PR TITLE
[Pygen] Fix post_randomize issue

### DIFF
--- a/pygen/pygen_src/isa/riscv_instr.py
+++ b/pygen/pygen_src/isa/riscv_instr.py
@@ -275,13 +275,6 @@ class riscv_instr:
             self.imm = self.imm_mask | self.imm
 
     def post_randomize(self):
-        pass
-
-    # TODO : This needs to be fix later
-    # Using a explicit post_process function calling it from riscv_instr_stream class
-    # because for some cases the post_randomization was not properly called
-    # and getting the output of imm value as none
-    def post_process(self):
         self.extend_imm()
         self.update_imm_str()
 

--- a/pygen/pygen_src/riscv_instr_stream.py
+++ b/pygen/pygen_src/riscv_instr_stream.py
@@ -228,5 +228,4 @@ class riscv_rand_instr_stream(riscv_instr_stream):
         it will be updated once randomization for list of enum types supports in PyVSC.
         """
         instr.randomize()
-        instr.post_process()
         return instr


### PR DESCRIPTION
The issue with post_randomize() was resolved in <https://github.com/fvutils/pyvsc/issues/17>.

Hence, the issue with **None** immediate value #642 is also resolved after getting support from PyVSC in its latest PyPI release.