### PR TITLE
initial custom CSR support

### DIFF
--- a/src/riscv_asm_program_gen.sv
+++ b/src/riscv_asm_program_gen.sv
@@ -747,6 +747,8 @@ class riscv_asm_program_gen extends uvm_object;
     end
     // Setup mepc register, jump to init entry
     setup_epc(hart);
+    // Initialization of any implementation-specific custom CSRs
+    setup_custom_csrs(hart);
     // Move privileged mode support to the "safe" section of the program
     // if PMP is supported
     if (riscv_instr_pkg::support_pmp) begin
@@ -827,6 +829,23 @@ class riscv_asm_program_gen extends uvm_object;
       cfg.pmp_cfg.gen_pmp_instr('{cfg.scratch_reg, cfg.gpr[0]}, instr);
       gen_section(get_label("pmp_setup", hart), instr);
     end
+  endfunction
+
+  // Handles creation of a subroutine to initialize any custom CSRs
+  virtual function void setup_custom_csrs(int hart);
+    string instr[$];
+    init_custom_csr(instr);
+    gen_section(get_label("custom_csr_setup", hart), instr);
+  endfunction
+
+  // This function should be overridden in the riscv_asm_program_gen extended class
+  // corresponding to the RTL implementation if it has any custom CSRs defined.
+  //
+  // All that needs to be done in the overridden function is to manually create
+  // the instruction strings to set up any custom CSRs and then to push those strings
+  // into the instr queue.
+  virtual function void init_custom_csr(ref string instr[$]);
+    instr.push_back("nop");
   endfunction
 
   //---------------------------------------------------------------------------------------

--- a/src/riscv_debug_rom_gen.sv
+++ b/src/riscv_debug_rom_gen.sv
@@ -223,17 +223,17 @@ class riscv_debug_rom_gen extends riscv_asm_program_gen;
   virtual function void gen_dcsr_ebreak();
     if (MACHINE_MODE inside {riscv_instr_pkg::supported_privileged_mode}) begin
       str = {$sformatf("li x%0d, 0x8000", cfg.scratch_reg),
-             $sformatf("csrs dcsr, x%0d", cfg.scratch_reg)};
+             $sformatf("csrs 0x%0x, x%0d", DCSR, cfg.scratch_reg)};
       debug_main = {debug_main, str};
     end
     if (SUPERVISOR_MODE inside {riscv_instr_pkg::supported_privileged_mode}) begin
       str = {$sformatf("li x%0d, 0x2000", cfg.scratch_reg),
-             $sformatf("csrs dcsr, x%0d", cfg.scratch_reg)};
+             $sformatf("csrs 0x%0x, x%0d", DCSR, cfg.scratch_reg)};
       debug_main = {debug_main, str};
     end
     if (USER_MODE inside {riscv_instr_pkg::supported_privileged_mode}) begin
       str = {$sformatf("li x%0d, 0x1000", cfg.scratch_reg),
-             $sformatf("csrs dcsr, x%0d", cfg.scratch_reg)};
+             $sformatf("csrs 0x%0x, x%0d", DCSR, cfg.scratch_reg)};
       debug_main = {debug_main, str};
     end
   endfunction

--- a/src/riscv_illegal_instr.sv
+++ b/src/riscv_illegal_instr.sv
@@ -133,6 +133,7 @@ class riscv_illegal_instr extends uvm_object;
       } else {
         // Invalid CSR instructions
         !(instr_bin[31:20] inside {csrs});
+        !(instr_bin[31:20] inside {custom_csr});
       }
     }
   }

--- a/src/riscv_instr_pkg.sv
+++ b/src/riscv_instr_pkg.sv
@@ -1013,6 +1013,10 @@ package riscv_instr_pkg;
     TDATA1          = 'h7A1,  // First Debug/Trace trigger data register
     TDATA2          = 'h7A2,  // Second Debug/Trace trigger data register
     TDATA3          = 'h7A3,  // Third Debug/Trace trigger data register
+    TINFO           = 'h7A4,  // Debug trigger info register
+    TCONTROL        = 'h7A5,  // Debug trigger control register
+    MCONTEXT        = 'h7A8,  // Machine mode trigger context register
+    SCONTEXT        = 'h7AA,  // Supervisor mode trigger context register
     DCSR            = 'h7B0,  // Debug control and status register
     DPC             = 'h7B1,  // Debug PC
     DSCRATCH0       = 'h7B2,  // Debug scratch register

--- a/target/ml/riscv_core_setting.sv
+++ b/target/ml/riscv_core_setting.sv
@@ -88,10 +88,10 @@ parameter int MAX_LMUL = 8;
 parameter int NUM_HARTS = 1;
 
 // ----------------------------------------------------------------------------
-// Previleged CSR implementation
+// Privileged CSR implementation
 // ----------------------------------------------------------------------------
 
-// Implemented previlieged CSR list
+// Implemented privileged CSR list
 `ifdef DSIM
 privileged_reg_t implemented_csr[] = {
 `else
@@ -112,6 +112,14 @@ const privileged_reg_t implemented_csr[] = {
     MCAUSE,     // Machine trap cause
     MTVAL,      // Machine bad address or instruction
     MIP         // Machine interrupt pending
+};
+
+// Implementation-specific custom CSRs
+`ifdef DSIM
+bit [11:0] custom_csr[] = {
+`else
+const bit [11:0] custom_csr[] = {
+`endif
 };
 
 // ----------------------------------------------------------------------------

--- a/target/multi_harts/riscv_core_setting.sv
+++ b/target/multi_harts/riscv_core_setting.sv
@@ -114,6 +114,14 @@ const privileged_reg_t implemented_csr[] = {
     MIP         // Machine interrupt pending
 };
 
+// Implementation-specific custom CSRs
+`ifdef DSIM
+bit [11:0] custom_csr[] = {
+`else
+const bit [11:0] custom_csr[] = {
+`endif
+};
+
 // ----------------------------------------------------------------------------
 // Supported interrupt/exception setting, used for functional coverage
 // ----------------------------------------------------------------------------

--- a/target/rv32i/riscv_core_setting.sv
+++ b/target/rv32i/riscv_core_setting.sv
@@ -114,6 +114,14 @@ const privileged_reg_t implemented_csr[] = {
     MIP         // Machine interrupt pending
 };
 
+// Implementation-specific custom CSRs
+`ifdef DSIM
+bit [11:0] custom_csr[] = {
+`else
+const bit [11:0] custom_csr[] = {
+`endif
+};
+
 // ----------------------------------------------------------------------------
 // Supported interrupt/exception setting, used for functional coverage
 // ----------------------------------------------------------------------------

--- a/target/rv32imc/riscv_core_setting.sv
+++ b/target/rv32imc/riscv_core_setting.sv
@@ -114,6 +114,14 @@ const privileged_reg_t implemented_csr[] = {
     MIP         // Machine interrupt pending
 };
 
+// Implementation-specific custom CSRs
+`ifdef DSIM
+bit [11:0] custom_csr[] = {
+`else
+const bit [11:0] custom_csr[] = {
+`endif
+};
+
 // ----------------------------------------------------------------------------
 // Supported interrupt/exception setting, used for functional coverage
 // ----------------------------------------------------------------------------

--- a/target/rv32imcb/riscv_core_setting.sv
+++ b/target/rv32imcb/riscv_core_setting.sv
@@ -114,6 +114,14 @@ const privileged_reg_t implemented_csr[] = {
     MIP         // Machine interrupt pending
 };
 
+// Implementation-specific custom CSRs
+`ifdef DSIM
+bit [11:0] custom_csr[] = {
+`else
+const bit [11:0] custom_csr[] = {
+`endif
+};
+
 // ----------------------------------------------------------------------------
 // Supported interrupt/exception setting, used for functional coverage
 // ----------------------------------------------------------------------------

--- a/target/rv64gc/riscv_core_setting.sv
+++ b/target/rv64gc/riscv_core_setting.sv
@@ -140,6 +140,14 @@ const privileged_reg_t implemented_csr[] = {
     FCSR        // Floating point control and status
 };
 
+// Implementation-specific custom CSRs
+`ifdef DSIM
+bit [11:0] custom_csr[] = {
+`else
+const bit [11:0] custom_csr[] = {
+`endif
+};
+
 // ----------------------------------------------------------------------------
 // Supported interrupt/exception setting, used for functional coverage
 // ----------------------------------------------------------------------------

--- a/target/rv64gcv/riscv_core_setting.sv
+++ b/target/rv64gcv/riscv_core_setting.sv
@@ -139,6 +139,14 @@ const privileged_reg_t implemented_csr[] = {
     FCSR        // Floating point control and status
 };
 
+// Implementation-specific custom CSRs
+`ifdef DSIM
+bit [11:0] custom_csr[] = {
+`else
+const bit [11:0] custom_csr[] = {
+`endif
+};
+
 // ----------------------------------------------------------------------------
 // Supported interrupt/exception setting, used for functional coverage
 // ----------------------------------------------------------------------------

--- a/target/rv64imc/riscv_core_setting.sv
+++ b/target/rv64imc/riscv_core_setting.sv
@@ -113,6 +113,14 @@ const privileged_reg_t implemented_csr[] = {
     MIP         // Machine interrupt pending
 };
 
+// Implementation-specific custom CSRs
+`ifdef DSIM
+bit [11:0] custom_csr[] = {
+`else
+const bit [11:0] custom_csr[] = {
+`endif
+};
+
 // ----------------------------------------------------------------------------
 // Supported interrupt/exception setting, used for functional coverage
 // ----------------------------------------------------------------------------

--- a/target/rv64imcb/riscv_core_setting.sv
+++ b/target/rv64imcb/riscv_core_setting.sv
@@ -114,6 +114,14 @@ const privileged_reg_t implemented_csr[] = {
     MIP         // Machine interrupt pending
 };
 
+// Implementation-specific custom CSRs
+`ifdef DSIM
+bit [11:0] custom_csr[] = {
+`else
+const bit [11:0] custom_csr[] = {
+`endif
+};
+
 // ----------------------------------------------------------------------------
 // Supported interrupt/exception setting, used for functional coverage
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
The first commit adds initial support for custom CSRs - users can specify them in `custom_csrs` in the `riscv_core_setting.sv`.
The second commit is just some cleanups in various places through the generator to remove hardcoded CSR names and replace them with the enumerated values.