### PR TITLE
Constraints should contain only integral types - fix error in riscv_vector_instr.sv

### DIFF
--- a/src/isa/riscv_vector_instr.sv
+++ b/src/isa/riscv_vector_instr.sv
@@ -183,7 +183,7 @@ class riscv_vector_instr extends riscv_floating_point_instr;
   // Vector register numbers accessed by the segment load or store would increment
   // cannot past 31
   constraint nfields_c {
-    if (check_sub_extension(sub_extension,"zvlsseg")) {
+    if (check_sub_extension(sub_extension, "zvlsseg")) {
       if (m_cfg.vector_cfg.vtype.vlmul < 8) {
         (nfields + 1) * m_cfg.vector_cfg.vtype.vlmul <= 8;
         if (category == LOAD) {
@@ -505,8 +505,8 @@ class riscv_vector_instr extends riscv_floating_point_instr;
     return $sformatf("%0s%0d%0s", prefix, nfields + 1, suffix);
   endfunction
   
-  function bit check_sub_extension(string s, literal);
-    return s==literal;
+  function bit check_sub_extension(string s, string literal);
+    return s == literal;
   endfunction
   
 endclass : riscv_vector_instr

--- a/src/isa/riscv_vector_instr.sv
+++ b/src/isa/riscv_vector_instr.sv
@@ -183,7 +183,7 @@ class riscv_vector_instr extends riscv_floating_point_instr;
   // Vector register numbers accessed by the segment load or store would increment
   // cannot past 31
   constraint nfields_c {
-    if (sub_extension == "zvlsseg") {
+    if (check_sub_extension(sub_extension,"zvlsseg")) {
       if (m_cfg.vector_cfg.vtype.vlmul < 8) {
         (nfields + 1) * m_cfg.vector_cfg.vtype.vlmul <= 8;
         if (category == LOAD) {
@@ -504,5 +504,9 @@ class riscv_vector_instr extends riscv_floating_point_instr;
     string suffix = instr_name.substr(prefix.len(), instr_name.len() - 1);
     return $sformatf("%0s%0d%0s", prefix, nfields + 1, suffix);
   endfunction
-
+  
+  function bit check_sub_extension(string s, literal);
+    return s==literal;
+  endfunction
+  
 endclass : riscv_vector_instr


### PR DESCRIPTION
According to SV standard (1800-2017, p.505):

> — Constraints can be any SystemVerilog expression with variables and constants of integral type (e.g.,
> bit, reg, logic, integer, enum, packed struct)"

The constraint:
https://github.com/google/riscv-dv/blob/10a7a1094d49c0e86c0b75e11894bfd241364ad7/src/isa/riscv_vector_instr.sv#L185-L186
uses comparison of string variable with literal which shouldn't be allowed.
The solution of the problem can be a replacing of the comparison with a function call. The actual comparison can be moved to the function as proposed in PR.