### PR TITLE
remove unreachable if statement

### DIFF
--- a/src/isa/riscv_instr_cov.svh
+++ b/src/isa/riscv_instr_cov.svh
@@ -160,9 +160,6 @@
       // unsigend immediate value
       bit [31:0] max_val;
       max_val = (1 << imm_len)-1;
-      if (value == '0) begin
-        return MIN_VAL;
-      end
       if (value == max_val) begin
         return MAX_VAL;
       end


### PR DESCRIPTION
Addresses an issue brought up by @hodjat91.

This `if...` statement will never be reached, as there is a previous check in the method to check whether `value == 0`, thus it can be removed without any side effects.