### PR TITLE
update directed pmp sequence constraint

### DIFF
--- a/src/riscv_pmp_cfg.sv
+++ b/src/riscv_pmp_cfg.sv
@@ -622,7 +622,7 @@ class riscv_pmp_cfg extends uvm_object;
     for (int i = 0; i < pmp_num_regions; i++) begin
       pmp_addr = base_pmp_addr + i;
       pmpcfg_addr = base_pmpcfg_addr + (i / cfg_per_csr);
-      // We randomize the upper 31 bits of pmp_val and then add this to the
+      // We randomize the lower 31 bits of pmp_val and then add this to the
       // address of <main>, guaranteeing that the random value written to
       // pmpaddr[i] doesn't interfere with the safe region.
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(pmp_val, pmp_val[31] == 1'b0;)
@@ -642,11 +642,14 @@ class riscv_pmp_cfg extends uvm_object;
       //
       // TODO: support rv64.
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(pmp_val,
-                                         // Need to constrain pmp_val[7], pmp_val[15], ... to 1'b0
-                                         // to ensure that the random config regions aren't locked
                                          foreach (pmp_val[i]) {
+                                           // constrain each Lock bit to 0
                                            if ((i+1) % 8 == 0) {
                                              pmp_val[i] == 1'b0;
+                                           }
+                                           // prevent W=1/R=0 combination
+                                           if (i % 8 == 0) { // this is an R bit
+                                             !((pmp_val[i] == 0) && (pmp_val[i+1] == 1'b1));
                                            }
                                          }
                                         )


### PR DESCRIPTION
In the directed PMP CSR write sequence, another constraint is needed to ensure the combination of R=0/W=1 does not occur, as this is undefined/unsupported behavior in the current spec.