### PR TITLE
[Pygen]: Fix minor issue

### DIFF
--- a/pygen/pygen_src/riscv_instr_gen_config.py
+++ b/pygen/pygen_src/riscv_instr_gen_config.py
@@ -264,6 +264,7 @@ class riscv_instr_gen_config:
         pass
 
     def post_randomize(self):
+        self.reserved_regs = []
         # Temporary fix for gpr_c constraint.
         self.gpr.extend((self.gpr0, self.gpr1, self.gpr2, self.gpr3))
 

--- a/pygen/pygen_src/riscv_instr_stream.py
+++ b/pygen/pygen_src/riscv_instr_stream.py
@@ -105,16 +105,16 @@ class riscv_instr_stream:
             new_instr[0].label = self.instr_list[idx].label
             new_instr[0].has_label = self.instr_list[idx].has_label
             if idx == 0:
-                self.instr_list = new_instr + self.instr_list[idx + 1:current_instr_cnt - 1]
-            else:
-                self.instr_list = self.instr_list[0:idx - 1] + new_instr + \
-                    self.instr_list[idx + 1:current_instr_cnt - 1]
-        else:
-            if idx == 0:
-                self.instr_list = new_instr + self.instr_list[idx:current_instr_cnt - 1]
+                self.instr_list = new_instr + self.instr_list[idx + 1:current_instr_cnt]
             else:
                 self.instr_list = self.instr_list[0:idx] + new_instr + \
-                    self.instr_list[idx:current_instr_cnt - 1]
+                    self.instr_list[idx + 1:current_instr_cnt]
+        else:
+            if idx == 0:
+                self.instr_list = new_instr + self.instr_list[idx:current_instr_cnt]
+            else:
+                self.instr_list = self.instr_list[0:idx] + new_instr + \
+                    self.instr_list[idx:current_instr_cnt]
 
     def mix_instr_stream(self, new_instr, contained = 0):
         """


### PR DESCRIPTION
The contents of **reserved_regs** are being appended when running multiple tests and hence at some point, the constraint solver getting failed for num_of_tests >100 mostly.
Clearing the contents of reserved_regs in post_randomize() such that it can have only three registers for a particular iteration.

There was a minor bug in **insert_instr_stream** function which is related to list slicing and hence it was creating forward branch label to appear at the end of main random instructions.
