### PR TITLE
fix ebreak generation bug

### DIFF
--- a/src/riscv_instr_stream.sv
+++ b/src/riscv_instr_stream.sv
@@ -234,8 +234,14 @@ class riscv_rand_instr_stream extends riscv_instr_stream;
         ((avail_regs.size() > 0) && !(SP inside {avail_regs}))) begin
       exclude_instr = {C_ADDI4SPN, C_ADDI16SP, C_LWSP, C_LDSP};
     end
-    if (is_in_debug && !cfg.enable_ebreak_in_debug_rom) begin
-      exclude_instr = {exclude_instr, EBREAK, C_EBREAK};
+    // Post-process the allowed_instr and exclude_instr lists to handle
+    // adding ebreak instructions to the debug rom.
+    if (is_in_debug) begin
+      if (cfg.no_ebreak && cfg.enable_ebreak_in_debug_rom) begin
+        allowed_instr = {allowed_instr, EBREAK, C_EBREAK};
+      end else if (!cfg.no_ebreak && !cfg.enable_ebreak_in_debug_rom) begin
+        exclude_instr = {exclude_instr, EBREAK, C_EBREAK};
+      end
     end
     instr = riscv_instr::get_rand_instr(.include_instr(allowed_instr),
                                         .exclude_instr(exclude_instr));


### PR DESCRIPTION
Fixes a small issue that caused ebreak instructions to incorrectly not be generated under the right set of config options.

Signed-off-by: Udi Jonnalagadda <udij@google.com>