### PR TITLE
Workaround of the SV compilation problem caused by assigning the const array variable with the empty concatenation.

### DIFF
--- a/target/ml/riscv_core_setting.sv
+++ b/target/ml/riscv_core_setting.sv
@@ -115,15 +115,7 @@ const privileged_reg_t implemented_csr[] = {
 };
 
 // Implementation-specific custom CSRs
-`ifdef DSIM
 bit [11:0] custom_csr[] = {
-`else
-`ifdef _VCP //DST713
-bit [11:0] custom_csr[] = {
-`else
-const bit [11:0] custom_csr[] = {
-`endif
-`endif
 };
 
 // ----------------------------------------------------------------------------

--- a/target/ml/riscv_core_setting.sv
+++ b/target/ml/riscv_core_setting.sv
@@ -118,7 +118,11 @@ const privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 bit [11:0] custom_csr[] = {
 `else
+`ifdef _VCP //DST713
+bit [11:0] custom_csr[] = {
+`else
 const bit [11:0] custom_csr[] = {
+`endif
 `endif
 };
 

--- a/target/multi_harts/riscv_core_setting.sv
+++ b/target/multi_harts/riscv_core_setting.sv
@@ -115,15 +115,7 @@ const privileged_reg_t implemented_csr[] = {
 };
 
 // Implementation-specific custom CSRs
-`ifdef DSIM
 bit [11:0] custom_csr[] = {
-`else
-`ifdef _VCP //DST713
-bit [11:0] custom_csr[] = {
-`else
-const bit [11:0] custom_csr[] = {
-`endif
-`endif
 };
 
 // ----------------------------------------------------------------------------

--- a/target/multi_harts/riscv_core_setting.sv
+++ b/target/multi_harts/riscv_core_setting.sv
@@ -118,7 +118,11 @@ const privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 bit [11:0] custom_csr[] = {
 `else
+`ifdef _VCP //DST713
+bit [11:0] custom_csr[] = {
+`else
 const bit [11:0] custom_csr[] = {
+`endif
 `endif
 };
 

--- a/target/rv32i/riscv_core_setting.sv
+++ b/target/rv32i/riscv_core_setting.sv
@@ -115,15 +115,7 @@ const privileged_reg_t implemented_csr[] = {
 };
 
 // Implementation-specific custom CSRs
-`ifdef DSIM
 bit [11:0] custom_csr[] = {
-`else
-`ifdef _VCP //DST713
-bit [11:0] custom_csr[] = {
-`else
-const bit [11:0] custom_csr[] = {
-`endif
-`endif
 };
 
 // ----------------------------------------------------------------------------

--- a/target/rv32i/riscv_core_setting.sv
+++ b/target/rv32i/riscv_core_setting.sv
@@ -118,7 +118,11 @@ const privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 bit [11:0] custom_csr[] = {
 `else
+`ifdef _VCP //DST713
+bit [11:0] custom_csr[] = {
+`else
 const bit [11:0] custom_csr[] = {
+`endif
 `endif
 };
 

--- a/target/rv32imc/riscv_core_setting.sv
+++ b/target/rv32imc/riscv_core_setting.sv
@@ -115,15 +115,7 @@ const privileged_reg_t implemented_csr[] = {
 };
 
 // Implementation-specific custom CSRs
-`ifdef DSIM
 bit [11:0] custom_csr[] = {
-`else
-`ifdef _VCP //DST713
-bit [11:0] custom_csr[] = {
-`else
-const bit [11:0] custom_csr[] = {
-`endif
-`endif
 };
 
 // ----------------------------------------------------------------------------

--- a/target/rv32imc/riscv_core_setting.sv
+++ b/target/rv32imc/riscv_core_setting.sv
@@ -118,7 +118,11 @@ const privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 bit [11:0] custom_csr[] = {
 `else
+`ifdef _VCP //DST713
+bit [11:0] custom_csr[] = {
+`else
 const bit [11:0] custom_csr[] = {
+`endif
 `endif
 };
 

--- a/target/rv32imc_sv32/riscv_core_setting.sv
+++ b/target/rv32imc_sv32/riscv_core_setting.sv
@@ -115,15 +115,7 @@ const privileged_reg_t implemented_csr[] = {
 };
 
 // Implementation-specific custom CSRs
-`ifdef DSIM
 bit [11:0] custom_csr[] = {
-`else
-`ifdef _VCP //DST713
-bit [11:0] custom_csr[] = {
-`else
-const bit [11:0] custom_csr[] = {
-`endif
-`endif
 };
 
 // ----------------------------------------------------------------------------

--- a/target/rv32imc_sv32/riscv_core_setting.sv
+++ b/target/rv32imc_sv32/riscv_core_setting.sv
@@ -118,7 +118,11 @@ const privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 bit [11:0] custom_csr[] = {
 `else
+`ifdef _VCP //DST713
+bit [11:0] custom_csr[] = {
+`else
 const bit [11:0] custom_csr[] = {
+`endif
 `endif
 };
 

--- a/target/rv32imcb/riscv_core_setting.sv
+++ b/target/rv32imcb/riscv_core_setting.sv
@@ -115,15 +115,7 @@ const privileged_reg_t implemented_csr[] = {
 };
 
 // Implementation-specific custom CSRs
-`ifdef DSIM
 bit [11:0] custom_csr[] = {
-`else
-`ifdef _VCP //DST713
-bit [11:0] custom_csr[] = {
-`else
-const bit [11:0] custom_csr[] = {
-`endif
-`endif
 };
 
 // ----------------------------------------------------------------------------

--- a/target/rv32imcb/riscv_core_setting.sv
+++ b/target/rv32imcb/riscv_core_setting.sv
@@ -118,7 +118,11 @@ const privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 bit [11:0] custom_csr[] = {
 `else
+`ifdef _VCP //DST713
+bit [11:0] custom_csr[] = {
+`else
 const bit [11:0] custom_csr[] = {
+`endif
 `endif
 };
 

--- a/target/rv64gc/riscv_core_setting.sv
+++ b/target/rv64gc/riscv_core_setting.sv
@@ -141,15 +141,7 @@ const privileged_reg_t implemented_csr[] = {
 };
 
 // Implementation-specific custom CSRs
-`ifdef DSIM
 bit [11:0] custom_csr[] = {
-`else
-`ifdef _VCP //DST713
-bit [11:0] custom_csr[] = {
-`else
-const bit [11:0] custom_csr[] = {
-`endif
-`endif
 };
 
 // ----------------------------------------------------------------------------

--- a/target/rv64gc/riscv_core_setting.sv
+++ b/target/rv64gc/riscv_core_setting.sv
@@ -144,7 +144,11 @@ const privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 bit [11:0] custom_csr[] = {
 `else
+`ifdef _VCP //DST713
+bit [11:0] custom_csr[] = {
+`else
 const bit [11:0] custom_csr[] = {
+`endif
 `endif
 };
 

--- a/target/rv64gcv/riscv_core_setting.sv
+++ b/target/rv64gcv/riscv_core_setting.sv
@@ -143,7 +143,11 @@ const privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 bit [11:0] custom_csr[] = {
 `else
+`ifdef _VCP //DST713
+bit [11:0] custom_csr[] = {
+`else
 const bit [11:0] custom_csr[] = {
+`endif
 `endif
 };
 

--- a/target/rv64gcv/riscv_core_setting.sv
+++ b/target/rv64gcv/riscv_core_setting.sv
@@ -140,15 +140,7 @@ const privileged_reg_t implemented_csr[] = {
 };
 
 // Implementation-specific custom CSRs
-`ifdef DSIM
 bit [11:0] custom_csr[] = {
-`else
-`ifdef _VCP //DST713
-bit [11:0] custom_csr[] = {
-`else
-const bit [11:0] custom_csr[] = {
-`endif
-`endif
 };
 
 // ----------------------------------------------------------------------------

--- a/target/rv64imc/riscv_core_setting.sv
+++ b/target/rv64imc/riscv_core_setting.sv
@@ -117,7 +117,11 @@ const privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 bit [11:0] custom_csr[] = {
 `else
+`ifdef _VCP //DST713
+bit [11:0] custom_csr[] = {
+`else
 const bit [11:0] custom_csr[] = {
+`endif
 `endif
 };
 

--- a/target/rv64imc/riscv_core_setting.sv
+++ b/target/rv64imc/riscv_core_setting.sv
@@ -114,15 +114,7 @@ const privileged_reg_t implemented_csr[] = {
 };
 
 // Implementation-specific custom CSRs
-`ifdef DSIM
 bit [11:0] custom_csr[] = {
-`else
-`ifdef _VCP //DST713
-bit [11:0] custom_csr[] = {
-`else
-const bit [11:0] custom_csr[] = {
-`endif
-`endif
 };
 
 // ----------------------------------------------------------------------------

--- a/target/rv64imcb/riscv_core_setting.sv
+++ b/target/rv64imcb/riscv_core_setting.sv
@@ -115,15 +115,7 @@ const privileged_reg_t implemented_csr[] = {
 };
 
 // Implementation-specific custom CSRs
-`ifdef DSIM
 bit [11:0] custom_csr[] = {
-`else
-`ifdef _VCP //DST713
-bit [11:0] custom_csr[] = {
-`else
-const bit [11:0] custom_csr[] = {
-`endif
-`endif
 };
 
 // ----------------------------------------------------------------------------

--- a/target/rv64imcb/riscv_core_setting.sv
+++ b/target/rv64imcb/riscv_core_setting.sv
@@ -118,7 +118,11 @@ const privileged_reg_t implemented_csr[] = {
 `ifdef DSIM
 bit [11:0] custom_csr[] = {
 `else
+`ifdef _VCP //DST713
+bit [11:0] custom_csr[] = {
+`else
 const bit [11:0] custom_csr[] = {
+`endif
 `endif
 };
 


### PR DESCRIPTION
There "initial custom CSR support" commit introduced an empty constant "custom_csr":
https://github.com/google/riscv-dv/blob/0645eeaf3e1cd5927c32372b3ae142323ca3e9e8/target/rv32imc/riscv_core_setting.sv#L117-L123

The initialization of a constant variable with the empty array concatenation expression causes compilation problem on some tools, e.g. Riviera-PRO. 
It seems that this empty const variable is not used in the generator code - is it really necessary? The creation of empty const array is a little strange - what is a reason for creation of such variable?

This PR contains a workaround for Riviera-PRO that is identical as this  already existing for DSIM.  