### PR TITLE
fix jumps to `test_done` and `init_[m/s/u]_mode`

### DIFF
--- a/src/riscv_asm_program_gen.sv
+++ b/src/riscv_asm_program_gen.sv
@@ -117,7 +117,10 @@ class riscv_asm_program_gen extends uvm_object;
       instr_stream = {instr_stream, main_program[hart].instr_string_list};
       // If PMP is supported, need to jump from end of main program to test_done section at the end
       // of main_program, as the test_done will have moved to the beginning of the program
-      instr_stream = {instr_stream, $sformatf("%sj test_done", indent)};
+      instr_stream = {instr_stream,
+                      $sformatf("%sla x%0d, test_done", indent, cfg.scratch_reg),
+                      $sformatf("%sjalr x0, x%0d, 0", indent, cfg.scratch_reg)
+                     };
       // Test done section
       // If PMP isn't supported, generate this in the normal location
       if (hart == 0 & !riscv_instr_pkg::support_pmp) begin
@@ -130,10 +133,6 @@ class riscv_asm_program_gen extends uvm_object;
       // Program end
       gen_program_end(hart);
       if (!cfg.bare_program_mode) begin
-        if (!riscv_instr_pkg::support_pmp) begin
-          // Privileged mode switch routine
-          gen_privileged_mode_switch_routine(hart);
-        end
         // Generate debug rom section
         if (riscv_instr_pkg::support_debug_mode) begin
           gen_debug_rom(hart);
@@ -329,7 +328,8 @@ class riscv_asm_program_gen extends uvm_object;
     end
     gen_section("_start", str);
     for (int hart = 0; hart < cfg.num_of_harts; hart++) begin
-      instr_stream.push_back($sformatf("%0d: j h%0d_start", hart, hart));
+      instr_stream.push_back($sformatf("%0d: la x%0d, h%0d_start", hart, cfg.scratch_reg, hart));
+      instr_stream.push_back($sformatf("jalr x0, x%0d, 0", cfg.scratch_reg));
     end
   endfunction
 
@@ -706,19 +706,19 @@ class riscv_asm_program_gen extends uvm_object;
   // TB can check the GPR value for this memory location to compare with expected value generated
   // by the ISA simulator. If the processor doesn't have a good tracer unit, it might not be
   // possible to compare the GPR value after each instruction execution.
-  virtual function void gen_register_dump();
+  virtual function void gen_register_dump(ref string instr[$]);
     string str;
     // Load base address
-    str = {indent, $sformatf("la x%0d, _start", cfg.gpr[0])};
-    instr_stream.push_back(str);
+    str = $sformatf("la x%0d, _start", cfg.gpr[0]);
+    instr.push_back(str);
     // Generate sw/sd instructions
     for(int i = 0; i < 32; i++) begin
       if(XLEN == 64) begin
-        str = {indent, $sformatf("sd x%0d, %0d(x%0d)", i, i*(XLEN/8), cfg.gpr[0])};
+        str = $sformatf("sd x%0d, %0d(x%0d)", i, i*(XLEN/8), cfg.gpr[0]);
       end else begin
-        str = {indent, $sformatf("sw x%0d, %0d(x%0d)", i, i*(XLEN/8), cfg.gpr[0])};
+        str = $sformatf("sw x%0d, %0d(x%0d)", i, i*(XLEN/8), cfg.gpr[0]);
       end
-      instr_stream.push_back(str);
+      instr.push_back(str);
     end
   endfunction
 
@@ -749,14 +749,10 @@ class riscv_asm_program_gen extends uvm_object;
     end
     // Setup mepc register, jump to init entry
     setup_epc(hart);
+    // Setup initial privilege mode
+    gen_privileged_mode_switch_routine(hart);
     // Initialization of any implementation-specific custom CSRs
     setup_custom_csrs(hart);
-    // Move privileged mode support to the "safe" section of the program
-    // if PMP is supported
-    if (riscv_instr_pkg::support_pmp) begin
-      // Privileged mode switch routine
-      gen_privileged_mode_switch_routine(hart);
-    end
   endfunction
 
   virtual function void gen_privileged_mode_switch_routine(int hart);
@@ -817,9 +813,6 @@ class riscv_asm_program_gen extends uvm_object;
     end
     mode_name = cfg.init_privileged_mode.name();
     instr.push_back($sformatf("csrw 0x%0x, x%0d", MEPC, cfg.gpr[0]));
-    if (!riscv_instr_pkg::support_pmp) begin
-      instr.push_back($sformatf("j %0sinit_%0s", hart_prefix(hart), mode_name.tolower()));
-    end
     gen_section(get_label("mepc_setup", hart), instr);
   endfunction
 
@@ -1092,7 +1085,9 @@ class riscv_asm_program_gen extends uvm_object;
                        cfg.gpr[0], cfg.gpr[1], hart_prefix(hart)),
              // Skip checking tval for illegal instruction as it's implementation specific
              $sformatf("csrr x%0d, 0x%0x # %0s", cfg.gpr[1], tval, tval.name()),
-             "1: jal x1, test_done "
+             // use JALR to jump to test_done.
+             $sformatf("1: la x%0d, test_done", cfg.scratch_reg),
+             $sformatf("jalr x1, x%0d, 0", cfg.scratch_reg)
            };
     gen_section(get_label($sformatf("%0smode_exception_handler", mode), hart), instr);
   endfunction
@@ -1138,7 +1133,8 @@ class riscv_asm_program_gen extends uvm_object;
       // Jump to commmon interrupt handling routine
       intr_handler = {intr_handler,
                       $sformatf("j %0s%0smode_intr_handler", hart_prefix(hart), mode),
-                      "1: j test_done"};
+                      $sformatf("1: la x%0d, test_done", cfg.scratch_reg),
+                      $sformatf("jalr x0, x%0d, 0", cfg.scratch_reg)};
       gen_section(get_label($sformatf("%0smode_intr_vector_%0d", mode, i), hart), intr_handler);
     end
   endfunction
@@ -1147,14 +1143,12 @@ class riscv_asm_program_gen extends uvm_object;
   // It does some clean up like dump GPRs before communicating with host to terminate the test.
   // User can extend this function if some custom clean up routine is needed.
   virtual function void gen_ecall_handler(int hart);
-    string str;
-    str = format_string(get_label("ecall_handler:", hart), LABEL_STR_LEN);
-    instr_stream.push_back(str);
-    dump_perf_stats();
-    gen_register_dump();
-    str = format_string(" ", LABEL_STR_LEN);
-    str = {str, "j write_tohost"};
-    instr_stream.push_back(str);
+    string instr[$];
+    dump_perf_stats(instr);
+    gen_register_dump(instr);
+    instr.push_back($sformatf("la x%0d, write_tohost", cfg.scratch_reg));
+    instr.push_back($sformatf("jalr x0, x%0d, 0", cfg.scratch_reg));
+    gen_section(get_label("ecall_handler", hart), instr);
   endfunction
 
   // Ebreak trap handler
@@ -1410,17 +1404,14 @@ class riscv_asm_program_gen extends uvm_object;
   endfunction
 
   // Dump performance CSRs if applicable
-  virtual function void dump_perf_stats();
-    string perf_stats[$];
+  virtual function void dump_perf_stats(ref string instr[$]);
     foreach(implemented_csr[i]) begin
       if (implemented_csr[i] inside {[MCYCLE:MHPMCOUNTER31H]}) begin
-        gen_signature_handshake(.instr(perf_stats),
+        gen_signature_handshake(.instr(instr),
                                 .signature_type(WRITE_CSR),
                                 .csr(implemented_csr[i]));
       end
     end
-    format_section(perf_stats);
-    instr_stream = {instr_stream, perf_stats};
   endfunction
 
   // Write the generated program to a file

--- a/src/riscv_pmp_cfg.sv
+++ b/src/riscv_pmp_cfg.sv
@@ -77,8 +77,6 @@ class riscv_pmp_cfg extends uvm_object;
     pmp_granularity inside {[0 : XLEN + 3]};
   }
 
-  // TODO(udinator) more address constraints?
-  // TODO(udinator) move to posts_randomize() if lower performance
   constraint xwr_c {
     foreach (pmp_cfg[i]) {
       !(pmp_cfg[i].w && !pmp_cfg[i].r);
@@ -438,7 +436,8 @@ class riscv_pmp_cfg extends uvm_object;
              $sformatf("li x%0d, 3", scratch_reg[0]),
              $sformatf("beq x%0d, x%0d, 27f", scratch_reg[4], scratch_reg[0]),
              // Error check, if no address modes match, something has gone wrong
-             $sformatf("j test_done"),
+             $sformatf("la x%0d, test_done", scratch_reg[0]),
+             $sformatf("jalr x0, x%0d, 0", scratch_reg[0]),
              /////////////////////////////////////////////////////////////////
              // increment loop counter and branch back to beginning of loop //
              /////////////////////////////////////////////////////////////////
@@ -459,7 +458,8 @@ class riscv_pmp_cfg extends uvm_object;
              // We must immediately jump to <test_done> since the CPU is taking a PMP exception,
              // but this routine is unable to find a matching PMP region for the faulting access -
              // there is a bug somewhere.
-             $sformatf("19: j test_done")
+             $sformatf("19: la x%0d, test_done", scratch_reg[0]),
+             $sformatf("jalr x0, x%0d, 0", scratch_reg[0])
             };
 
     /////////////////////////////////////////////////
@@ -495,8 +495,8 @@ class riscv_pmp_cfg extends uvm_object;
              // <test_done>, otherwise modify access bits and return
              $sformatf("andi x%0d, x%0d, 128", scratch_reg[4], scratch_reg[3]),
              $sformatf("beqz x%0d, 24f", scratch_reg[4]),
-             $sformatf("j test_done"),
-             // TODO : update with correct label
+             $sformatf("la x%0d, test_done", scratch_reg[0]),
+             $sformatf("jalr x0, x%0d, 0", scratch_reg[0]),
              $sformatf("24: j 29f")
             };
 
@@ -515,8 +515,8 @@ class riscv_pmp_cfg extends uvm_object;
              // entry is locked, otherwise modify access bits
              $sformatf("andi x%0d, x%0d, 128", scratch_reg[4], scratch_reg[3]),
              $sformatf("beqz x%0d, 26f", scratch_reg[4]),
-             $sformatf("j test_done"),
-             // TODO : update with correct label
+             $sformatf("la x%0d, test_done", scratch_reg[0]),
+             $sformatf("jalr x0, x%0d, 0", scratch_reg[0]),
              $sformatf("26: j 29f")
             };
 
@@ -540,8 +540,8 @@ class riscv_pmp_cfg extends uvm_object;
              // the entry is locked, otherwise modify access bits
              $sformatf("andi x%0d, x%0d, 128", scratch_reg[4], scratch_reg[3]),
              $sformatf("beqz x%0d, 29f", scratch_reg[4]),
-             $sformatf("j test_done"),
-             // TODO : update with correct label
+             $sformatf("la x%0d, test_done", scratch_reg[0]),
+             $sformatf("jalr x0, x%0d, 0", scratch_reg[0]),
              $sformatf("28: j 29f")
            };
 


### PR DESCRIPTION
From #709, it appears there is an issue jumping to `init_machine_mode`
when generating a large (200k instructions) program.
This is because we currently use a standard `j` instruction to do the
jump which only has a 20-bit address range, so this range is exceeded in
a program of this size.
Similar issues arise when jumping to `test_done` and `write_tohost` from 
various exception handlers.

The solution is as follows:

1) Move the `init_[m/s/u]_mode` section to the top of the program to
prevent us from having to jump there in the first place - this does not
cause any side effects.
2) Change the jump mechanisms to `test_done` and `write_tohost` from `j test_done` to
preloading the address of `test_done` into a register and using a `jalr`
instruction to jump to this address - this allows us to cover a full
XLEN-bit address space when jumping around the program.

This PR also refactors `gen_ecall_handler()`, and includes the above changes.