### PR TITLE
Convert python codes to be PEP8 compliant

### DIFF
--- a/cov.py
+++ b/cov.py
@@ -30,290 +30,315 @@ from types import SimpleNamespace
 
 LOGGER = logging.getLogger()
 
-def build_cov(out, cfg, cwd, opts_vec, opts_cov):
-  """Building the coverage collection framework
 
-  Args:
-    out                 : Output directory
-    cfg                 : Loaded configuration dictionary.
-    cwd                 : Filesystem path to RISCV-DV repo
-    opts_vec            : Vector options
-    opts_cov            : Coverage options
-  """
-  # Convert key dictionary to argv variable
-  argv= SimpleNamespace(**cfg)
-  logging.info("Building the coverage collection framework")
-  build_cmd = ("python3 %s/run.py --simulator %s --simulator_yaml %s "
-                " --co -o %s --cov -tl %s %s --cmp_opts \"%s %s\" --noclean" %
-                (cwd, argv.simulator, argv.simulator_yaml, out, argv.testlist, argv.opts,
-                 opts_vec, opts_cov))
-  if argv.target:
-    build_cmd += (" --target %s" % argv.target)
-  if argv.custom_target:
-    build_cmd += (" --custom_target %s" % argv.custom_target)
-  if argv.stop_on_first_error:
-    build_cmd += (" --stop_on_first_error")
-  if argv.lsf_cmd != "":
-    build_cmd += (" --lsf_cmd \"%s\"" % argv.lsf_cmd)
-    run_parallel_cmd([build_cmd], argv.timeout, debug_cmd = argv.debug)
-  else:
-    run_cmd(build_cmd, debug_cmd = argv.debug)
+def build_cov(out, cfg, cwd, opts_vec, opts_cov):
+    """Building the coverage collection framework
+
+    Args:
+      out                 : Output directory
+      cfg                 : Loaded configuration dictionary.
+      cwd                 : Filesystem path to RISCV-DV repo
+      opts_vec            : Vector options
+      opts_cov            : Coverage options
+    """
+    # Convert key dictionary to argv variable
+    argv = SimpleNamespace(**cfg)
+    logging.info("Building the coverage collection framework")
+    build_cmd = ("python3 {}/run.py --simulator {} --simulator_yaml {} "
+                 " --co -o {} --cov -tl {} {} --cmp_opts \"{} {}\" --noclean".format(
+        cwd, argv.simulator, argv.simulator_yaml, out,
+        argv.testlist, argv.opts, opts_vec, opts_cov))
+    if argv.target:
+        build_cmd += (" --target {}".format(argv.target))
+    if argv.custom_target:
+        build_cmd += (" --custom_target {}".format(argv.custom_target))
+    if argv.stop_on_first_error:
+        build_cmd += " --stop_on_first_error"
+    if argv.lsf_cmd != "":
+        build_cmd += (" --lsf_cmd \"{}\"".format(argv.lsf_cmd))
+        run_parallel_cmd([build_cmd], argv.timeout, debug_cmd=argv.debug)
+    else:
+        run_cmd(build_cmd, debug_cmd=argv.debug)
+
 
 def sim_cov(out, cfg, cwd, opts_vec, opts_cov, csv_list):
-  """Simulation the coverage collection
+    """Simulation the coverage collection
 
-  Args:
-    out                 : Output directory
-    cfg                 : Loaded configuration dictionary.
-    cwd                 : Filesystem path to RISCV-DV repo
-    opts_vec            : Vector options
-    opts_cov            : Coverage options
-    csv_list            : The list of trace csv
-  """
-  # Convert key dictionary to argv variable
-  argv= SimpleNamespace(**cfg)
-  logging.info("Collecting functional coverage from %0d trace CSV" % len(csv_list))
-  test_name = "riscv_instr_cov_test"
-  base_sim_cmd = ("python3 %s/run.py --simulator %s --simulator_yaml %s --noclean "
-                  "--so -o %s --cov -tl %s %s "
-                  "-tn %s --steps gen --sim_opts \"<trace_csv_opts> %s %s <visualization>\" " %
-                  (cwd, argv.simulator, argv.simulator_yaml, out, argv.testlist,
-                   argv.opts, test_name, opts_vec, opts_cov))
-  if argv.simulator == "pyflow" and argv.enable_visualization: 
-    base_sim_cmd = re.sub("<visualization>", "--enable_visualization", base_sim_cmd)
-  else:
-    base_sim_cmd = re.sub("<visualization>", "", base_sim_cmd)
-  if argv.target:
-    base_sim_cmd += (" --target %s" % argv.target)
-  if argv.custom_target:
-    base_sim_cmd += (" --custom_target %s" % argv.custom_target)
-  if argv.stop_on_first_error:
-    base_sim_cmd += (" --stop_on_first_error")
-  trace_csv_opts = ""
-  batch_cnt = 1
-  sim_cmd_list = []
-  if argv.batch_size > 0:
-    batch_cnt = (len(csv_list) + argv.batch_size - 1) / argv.batch_size
-    logging.info("Batch size: %0d, Batch cnt:%0d" % (argv.batch_size, batch_cnt))
-  for i in range(len(csv_list)):
-    file_idx = 0
-    trace_idx = i
-    if argv.batch_size > 0:
-      file_idx = i / argv.batch_size
-      trace_idx = i % argv.batch_size
-    if argv.simulator == "pyflow":
-      if i == 0:
-        trace_csv_opts += (" --trace_csv=%s" % csv_list[i])
-      else:
-        trace_csv_opts += (",%s" % csv_list[i])
+    Args:
+      out                 : Output directory
+      cfg                 : Loaded configuration dictionary.
+      cwd                 : Filesystem path to RISCV-DV repo
+      opts_vec            : Vector options
+      opts_cov            : Coverage options
+      csv_list            : The list of trace csv
+    """
+    # Convert key dictionary to argv variable
+    argv = SimpleNamespace(**cfg)
+    logging.info(
+        "Collecting functional coverage from {} trace CSV".format(len(csv_list)))
+    test_name = "riscv_instr_cov_test"
+    base_sim_cmd = (
+        "python3 {}/run.py --simulator {} --simulator_yaml {} --noclean "
+        "--so -o {} --cov -tl {} {} "
+        "-tn {} --steps gen --sim_opts \"<trace_csv_opts> {} {} <visualization>\" "
+            .format(cwd, argv.simulator, argv.simulator_yaml, out,
+                    argv.testlist,
+                    argv.opts, test_name, opts_vec, opts_cov))
+    if argv.simulator == "pyflow" and argv.enable_visualization:
+        base_sim_cmd = re.sub("<visualization>", "--enable_visualization",
+                              base_sim_cmd)
     else:
-      trace_csv_opts += (" +trace_csv_%0d=%s" % (trace_idx, csv_list[i]))
-    if (i == len(csv_list)-1) or ((argv.batch_size > 0) and (trace_idx == argv.batch_size-1)):
-      sim_cmd = base_sim_cmd.replace("<trace_csv_opts>", trace_csv_opts)
-      sim_cmd += ("  --log_suffix _%d" % file_idx)
-      if argv.lsf_cmd == "":
-        logging.info("Processing batch %0d/%0d" % (file_idx+1, batch_cnt))
-        run_cmd(sim_cmd, debug_cmd = argv.debug)
-      else:
-        sim_cmd += (" --lsf_cmd \"%s\"" % argv.lsf_cmd)
-        sim_cmd_list.append(sim_cmd)
-      trace_csv_opts = ""
-  if argv.lsf_cmd != "":
-    run_parallel_cmd(sim_cmd_list, argv.timeout)
-  logging.info("Collecting functional coverage from %0d trace CSV...done" % len(csv_list))
+        base_sim_cmd = re.sub("<visualization>", "", base_sim_cmd)
+    if argv.target:
+        base_sim_cmd += (" --target {}".format(argv.target))
+    if argv.custom_target:
+        base_sim_cmd += (" --custom_target {}".format(argv.custom_target))
+    if argv.stop_on_first_error:
+        base_sim_cmd += " --stop_on_first_error"
+    trace_csv_opts = ""
+    batch_cnt = 1
+    sim_cmd_list = []
+    if argv.batch_size > 0:
+        batch_cnt = (len(csv_list) + argv.batch_size - 1) / argv.batch_size
+        logging.info(
+            "Batch size: {}, Batch cnt: {}".format(argv.batch_size, batch_cnt))
+    for i in range(len(csv_list)):
+        file_idx = 0
+        trace_idx = i
+        if argv.batch_size > 0:
+            file_idx = i / argv.batch_size
+            trace_idx = i % argv.batch_size
+        if argv.simulator == "pyflow":
+            if i == 0:
+                trace_csv_opts += (" --trace_csv={}".format(csv_list[i]))
+            else:
+                trace_csv_opts += (",{}".format(csv_list[i]))
+        else:
+            trace_csv_opts += (" +trace_csv_{}={}".format(trace_idx, csv_list[i]))
+        if (i == len(csv_list) - 1) or (
+                (argv.batch_size > 0) and (trace_idx == argv.batch_size - 1)):
+            sim_cmd = base_sim_cmd.replace("<trace_csv_opts>", trace_csv_opts)
+            sim_cmd += ("  --log_suffix _{}".format(file_idx))
+            if argv.lsf_cmd == "":
+                logging.info(
+                    "Processing batch {}/{}".format(file_idx + 1, batch_cnt))
+                run_cmd(sim_cmd, debug_cmd=argv.debug)
+            else:
+                sim_cmd += (" --lsf_cmd \"{}\"".format(argv.lsf_cmd))
+                sim_cmd_list.append(sim_cmd)
+            trace_csv_opts = ""
+    if argv.lsf_cmd != "":
+        run_parallel_cmd(sim_cmd_list, argv.timeout)
+    logging.info(
+        "Collecting functional coverage from {} trace CSV...done".format(len(
+            csv_list)))
+
 
 def collect_cov(out, cfg, cwd):
-  """Collect functional coverage from the instruction trace
+    """Collect functional coverage from the instruction trace
 
-  Args:
-    out              : Output directory
-    cfg              : Loaded configuration dictionary.
-    cwd              : Filesystem path to RISCV-DV repo
-  """
-  # Convert key dictionary to argv variable
-  argv= SimpleNamespace(**cfg)
-  log_list = []
-  csv_list = []
-  if not argv.dir:
-    logging.error("Missing directory of trace log files")
-    sys.exit(RET_FAIL)
-  logging.info("Processing trace log under %s" % argv.dir)
-  if not os.path.isdir(argv.dir) or not os.listdir(argv.dir):
-    if not argv.debug:
-      logging.error("Cannot find %s directory, or it is empty", argv.dir)
-      sys.exit(RET_FAIL)
-  if argv.core:
+    Args:
+      out              : Output directory
+      cfg              : Loaded configuration dictionary.
+      cwd              : Filesystem path to RISCV-DV repo
     """
-    If functional coverage is being collected from an RTL core implementation,
-    the flow assumes that the core's trace logs have already been converted to
-    CSV files by the post_compare step of the flow.
-    """
-    trace_log = ("%s/%s_trace_log" % (out, argv.core))
-    run_cmd("find %s -name \"*.csv\" | sort > %s" % (argv.dir, trace_log))
-  else:
-    trace_log = ("%s/%s_trace_log" % (out, argv.iss))
-    run_cmd("find %s -name \"*.log\" | sort > %s" % (argv.dir, trace_log))
-  with open(trace_log) as f:
-    for line in f:
-      line = line.rstrip()
-      log_list.append(line)
-      csv = line[0:-4] + ".csv"
-      csv_list.append(csv)
-  if argv.steps == "all" or re.match("csv", argv.steps):
-    for i in range(len(log_list)):
-      log = log_list[i]
-      csv = csv_list[i]
-      # If a core target is defined, prioritize over ISS
-      if argv.core:
-        logging.info("Process %0s log[%0d/%0d] : %s" % (argv.core, i+1, len(log_list), log))
-      else:
-        logging.info("Process %0s log[%0d/%0d] : %s" % (argv.iss, i+1, len(log_list), log))
-        if argv.iss == "spike":
-          process_spike_sim_log(log, csv, 1)
-        elif argv.iss == "ovpsim":
-          process_ovpsim_sim_log(log, csv, argv.stop_on_first_error,
-                                 argv.dont_truncate_after_first_ecall, 1)
-        else:
-          logging.error("Full trace for %s is not supported yet" % argv.iss)
-          sys.exit(RET_FAIL)
-  if argv.steps == "all" or re.match("cov", argv.steps):
-    opts_vec = ""
-    opts_cov = ""
-    if argv.vector_options:
-      opts_vec = ("%0s" % argv.vector_options)
-    if argv.coverage_options:
-      opts_cov = ("%0s" % argv.coverage_options)
-    if argv.compliance_mode:
-      opts_cov += " +define+COMPLIANCE_MODE"
-    # Building the coverage collection framework
-    if argv.simulator != "pyflow":
-      build_cov(out, cfg, cwd, opts_vec, opts_cov)
-    # Simulation the coverage collection
-    sim_cov(out, cfg, cwd, opts_vec, opts_cov, csv_list)
+    # Convert key dictionary to argv variable
+    argv = SimpleNamespace(**cfg)
+    log_list = []
+    csv_list = []
+    if not argv.dir:
+        logging.error("Missing directory of trace log files")
+        sys.exit(RET_FAIL)
+    logging.info("Processing trace log under {}".format(argv.dir))
+    if not os.path.isdir(argv.dir) or not os.listdir(argv.dir):
+        if not argv.debug:
+            logging.error("Cannot find {} directory, or it is empty".format(argv.dir))
+            sys.exit(RET_FAIL)
+    if argv.core:
+        """If functional coverage is being collected from an RTL core 
+        implementation, the flow assumes that the core's trace logs have 
+        already been converted to CSV files by the post_compare step of the 
+        flow. """
+        trace_log = ("{}/{}_trace_log".format(out, argv.core))
+        run_cmd("find {} -name \"*.csv\" | sort > {}".format(argv.dir, trace_log))
+    else:
+        trace_log = ("{}/{}_trace_log".format(out, argv.iss))
+        run_cmd("find {} -name \"*.log\" | sort > {}".format(argv.dir, trace_log))
+    with open(trace_log) as f:
+        for line in f:
+            line = line.rstrip()
+            log_list.append(line)
+            csv = line[0:-4] + ".csv"
+            csv_list.append(csv)
+    if argv.steps == "all" or re.match("csv", argv.steps):
+        for i in range(len(log_list)):
+            log = log_list[i]
+            csv = csv_list[i]
+            # If a core target is defined, prioritize over ISS
+            if argv.core:
+                logging.info("Process {} log[{}/{}] : {}".format(
+                    argv.core, i + 1, len(log_list), log))
+            else:
+                logging.info("Process {} log[{}/{}] : {}".format(
+                    argv.iss, i + 1, len(log_list), log))
+                if argv.iss == "spike":
+                    process_spike_sim_log(log, csv, 1)
+                elif argv.iss == "ovpsim":
+                    process_ovpsim_sim_log(log, csv, argv.stop_on_first_error,
+                                           argv.dont_truncate_after_first_ecall,
+                                           1)
+                else:
+                    logging.error(
+                        "Full trace for {} is not supported yet".format(argv.iss))
+                    sys.exit(RET_FAIL)
+    if argv.steps == "all" or re.match("cov", argv.steps):
+        opts_vec = ""
+        opts_cov = ""
+        if argv.vector_options:
+            opts_vec = ("{}".format(argv.vector_options))
+        if argv.coverage_options:
+            opts_cov = ("{}".format(argv.coverage_options))
+        if argv.compliance_mode:
+            opts_cov += " +define+COMPLIANCE_MODE"
+        # Building the coverage collection framework
+        if argv.simulator != "pyflow":
+            build_cov(out, cfg, cwd, opts_vec, opts_cov)
+        # Simulation the coverage collection
+        sim_cov(out, cfg, cwd, opts_vec, opts_cov, csv_list)
+
 
 def setup_parser():
-  """Create a command line parser.
+    """Create a command line parser.
 
-  Returns: The created parser.
-  """
-  # Parse input arguments
-  parser = argparse.ArgumentParser()
-  parser.add_argument("-o", "--output", type=str,
-                      help="Output directory name", dest="o")
-  parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", default=False,
-                      help="Verbose logging")
-  parser.add_argument("--dir", type=str,
-                      help="Directory of trace log files")
-  parser.add_argument("-bz", "--batch_size", dest="batch_size", type=int, default=0,
-                      help="Number of CSV to process per run")
-  parser.add_argument("--compliance_mode", action="store_true", default=False,
-                      help="Run the coverage model in compliance test mode")
-  parser.add_argument("-i", "--instr_cnt", dest="instr_cnt", type=int, default=0,
-                      help="Random instruction count for debug mode")
-  parser.add_argument("-to", "--timeout", dest="timeout", type=int, default=1000,
-                      help="Number of CSV to process per run")
-  parser.add_argument("-s", "--steps", type=str, default="all",
-                      help="Run steps: csv,cov", dest="steps")
-  parser.add_argument("--core", type=str, default="",
-                      help="Name of target core")
-  parser.add_argument("--isa", type=str, default="",
-                      help="RISC-V ISA variant")
-  parser.add_argument("--iss", type=str, default="spike",
-                      help="RISC-V instruction set simulator: spike,ovpsim,sail")
-  parser.add_argument("-tl", "--testlist", type=str, default="",
-                      help="Regression testlist", dest="testlist")
-  parser.add_argument("--opts", type=str, default="",
-                      help="Additional options for the instruction generator")
-  parser.add_argument("--lsf_cmd", type=str, default="",
-                      help="LSF command. Run in local sequentially if lsf \
+    Returns: The created parser.
+    """
+    # Parse input arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-o", "--output", type=str,
+                        help="Output directory name", dest="o")
+    parser.add_argument("-v", "--verbose", dest="verbose", action="store_true",
+                        default=False,
+                        help="Verbose logging")
+    parser.add_argument("--dir", type=str,
+                        help="Directory of trace log files")
+    parser.add_argument("-bz", "--batch_size", dest="batch_size", type=int,
+                        default=0,
+                        help="Number of CSV to process per run")
+    parser.add_argument("--compliance_mode", action="store_true", default=False,
+                        help="Run the coverage model in compliance test mode")
+    parser.add_argument("-i", "--instr_cnt", dest="instr_cnt", type=int,
+                        default=0,
+                        help="Random instruction count for debug mode")
+    parser.add_argument("-to", "--timeout", dest="timeout", type=int,
+                        default=1000,
+                        help="Number of CSV to process per run")
+    parser.add_argument("-s", "--steps", type=str, default="all",
+                        help="Run steps: csv,cov", dest="steps")
+    parser.add_argument("--core", type=str, default="",
+                        help="Name of target core")
+    parser.add_argument("--isa", type=str, default="",
+                        help="RISC-V ISA variant")
+    parser.add_argument("--iss", type=str, default="spike",
+                        help="RISC-V instruction set simulator: spike,ovpsim,sail")
+    parser.add_argument("-tl", "--testlist", type=str, default="",
+                        help="Regression testlist", dest="testlist")
+    parser.add_argument("--opts", type=str, default="",
+                        help="Additional options for the instruction generator")
+    parser.add_argument("--lsf_cmd", type=str, default="",
+                        help="LSF command. Run in local sequentially if lsf \
                             command is not specified")
-  parser.add_argument("--target", type=str, default="rv32imc",
-                      help="Run the generator with pre-defined targets: \
+    parser.add_argument("--target", type=str, default="rv32imc",
+                        help="Run the generator with pre-defined targets: \
                             rv32imc, rv32i, rv64imc, rv64gc")
-  parser.add_argument("-si", "--simulator", type=str, default="vcs",
-                      help="Simulator used to run the generator, \
+    parser.add_argument("-si", "--simulator", type=str, default="vcs",
+                        help="Simulator used to run the generator, \
                             default VCS", dest="simulator")
-  parser.add_argument("--simulator_yaml", type=str, default="",
-                      help="RTL simulator setting YAML")
-  parser.add_argument("-ct", "--custom_target", type=str, default="",
-                      help="Directory name of the custom target")
-  parser.add_argument("-cs", "--core_setting_dir", type=str, default="",
-                      help="Path for the riscv_core_setting.sv")
-  parser.add_argument("--stop_on_first_error", dest="stop_on_first_error",
-                      action="store_true", default=False,
-                      help="Stop on detecting first error")
-  parser.add_argument("--dont_truncate_after_first_ecall", dest="dont_truncate_after_first_ecall",
-                      action="store_true", default=False,
-                      help="Do not truncate log and csv file on first ecall")
-  parser.add_argument("--noclean", action="store_true", default=False,
-                      help="Do not clean the output of the previous runs")
-  parser.add_argument("--vector_options", type=str, default="",
-                      help="Enable Vectors and set options")
-  parser.add_argument("--coverage_options", type=str, default="",
-                      help="Controlling coverage coverpoints")
-  parser.add_argument("--exp", action="store_true", default=False,
-                      help="Run generator with experimental features")
-  parser.add_argument("-d", "--debug", type=str, default="",
-                      help="Generate debug command log file")
-  parser.add_argument("--enable_visualization", action="store_true", default=False,
-                      help="Enabling coverage report visualization for pyflow")
-  return parser
+    parser.add_argument("--simulator_yaml", type=str, default="",
+                        help="RTL simulator setting YAML")
+    parser.add_argument("-ct", "--custom_target", type=str, default="",
+                        help="Directory name of the custom target")
+    parser.add_argument("-cs", "--core_setting_dir", type=str, default="",
+                        help="Path for the riscv_core_setting.sv")
+    parser.add_argument("--stop_on_first_error", dest="stop_on_first_error",
+                        action="store_true", default=False,
+                        help="Stop on detecting first error")
+    parser.add_argument("--dont_truncate_after_first_ecall",
+                        dest="dont_truncate_after_first_ecall",
+                        action="store_true", default=False,
+                        help="Do not truncate log and csv file on first ecall")
+    parser.add_argument("--noclean", action="store_true", default=False,
+                        help="Do not clean the output of the previous runs")
+    parser.add_argument("--vector_options", type=str, default="",
+                        help="Enable Vectors and set options")
+    parser.add_argument("--coverage_options", type=str, default="",
+                        help="Controlling coverage coverpoints")
+    parser.add_argument("--exp", action="store_true", default=False,
+                        help="Run generator with experimental features")
+    parser.add_argument("-d", "--debug", type=str, default="",
+                        help="Generate debug command log file")
+    parser.add_argument("--enable_visualization", action="store_true",
+                        default=False,
+                        help="Enabling coverage report visualization for pyflow")
+    return parser
+
 
 def load_config(args, cwd):
-  """
-  Load configuration from the command line and the configuration file.
+    """
+    Load configuration from the command line and the configuration file.
 
-  Args:
-      args:   Parsed command-line configuration
-  Returns:
-      Loaded configuration dictionary.
-  """
-  if args.debug:
-    args.debug = open(args.debug, "w")
-  if args.verbose:
-    args.opts += "-v"
+    Args:
+        args:   Parsed command-line configuration
+    Returns:
+        Loaded configuration dictionary.
+    """
+    if args.debug:
+        args.debug = open(args.debug, "w")
+    if args.verbose:
+        args.opts += "-v"
 
-  if not args.simulator_yaml:
-    args.simulator_yaml = cwd + "/yaml/simulator.yaml"
+    if not args.simulator_yaml:
+        args.simulator_yaml = cwd + "/yaml/simulator.yaml"
 
-  # Disable ISS coverage if a core is passed in
-  if args.core:
-    args.iss = ""
+    # Disable ISS coverage if a core is passed in
+    if args.core:
+        args.iss = ""
 
-  # Keep the core_setting_dir option to be backward compatible, suggest to use
-  # --custom_target
-  if args.core_setting_dir:
+    # Keep the core_setting_dir option to be backward compatible, suggest to use
+    # --custom_target
+    if args.core_setting_dir:
+        if not args.custom_target:
+            args.custom_target = args.core_setting_dir
+    else:
+        args.core_setting_dir = args.custom_target
+
     if not args.custom_target:
-      args.custom_target = args.core_setting_dir
-  else:
-    args.core_setting_dir = args.custom_target
+        args.core_setting_dir = cwd + "/target/" + args.target
 
-  if not args.custom_target:
-    args.core_setting_dir = cwd + "/target/"+ args.target
+    args.testlist = cwd + "/yaml/cov_testlist.yaml"  ## needed if need to force
+    # Create loaded configuration dictionary.
+    cfg = vars(args)
+    return cfg
 
-  args.testlist = cwd + "/yaml/cov_testlist.yaml" ## needed if need to force
-  # Create loaded configuration dictionary.
-  cfg = vars(args)
-  return cfg
 
 def main():
-  """This is the main entry point."""
-  try:
-    parser = setup_parser()
-    args = parser.parse_args()
-    cwd = os.path.dirname(os.path.realpath(__file__))
-    setup_logging(args.verbose)
-    # Load configuration from the command line and the configuration file.
-    cfg = load_config(args, cwd)
-    # Create output directory
-    output_dir = create_output(args.o, args.noclean, "cov_out_")
-    # Collect coverage for the trace CSV
-    collect_cov(output_dir, cfg ,cwd)
-    logging.info("Coverage results are saved to %s" % output_dir)
-    sys.exit(RET_SUCCESS)
-  except KeyboardInterrupt:
-    logging.info("\nExited Ctrl-C from user request.")
-    sys.exit(130)
+    """This is the main entry point."""
+    try:
+        parser = setup_parser()
+        args = parser.parse_args()
+        cwd = os.path.dirname(os.path.realpath(__file__))
+        setup_logging(args.verbose)
+        # Load configuration from the command line and the configuration file.
+        cfg = load_config(args, cwd)
+        # Create output directory
+        output_dir = create_output(args.o, args.noclean, "cov_out_")
+        # Collect coverage for the trace CSV
+        collect_cov(output_dir, cfg, cwd)
+        logging.info("Coverage results are saved to {}".format(output_dir))
+        sys.exit(RET_SUCCESS)
+    except KeyboardInterrupt:
+        logging.info("\nExited Ctrl-C from user request.")
+        sys.exit(130)
+
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/run.py
+++ b/run.py
@@ -36,663 +36,703 @@ LOGGER = logging.getLogger()
 
 
 class SeedGen:
-  '''An object that will generate a pseudo-random seed for test iterations'''
-  def __init__(self, start_seed, fixed_seed, seed_yaml):
-    # These checks are performed with proper error messages at argument parsing
-    # time, but it can't hurt to do a belt-and-braces check here too.
-    assert fixed_seed is None or start_seed is None
+    """An object that will generate a pseudo-random seed for test iterations"""
 
-    self.fixed_seed = fixed_seed
-    self.start_seed = start_seed
-    self.rerun_seed = {} if seed_yaml is None else read_yaml(seed_yaml)
+    def __init__(self, start_seed, fixed_seed, seed_yaml):
+        # These checks are performed with proper error messages at argument
+        # parsing time, but it can't hurt to do a belt-and-braces check here too.
+        assert fixed_seed is None or start_seed is None
 
-  def get(self, test_id, test_iter):
-    '''Get the seed to use for the given test and iteration'''
+        self.fixed_seed = fixed_seed
+        self.start_seed = start_seed
+        self.rerun_seed = {} if seed_yaml is None else read_yaml(seed_yaml)
 
-    if test_id in self.rerun_seed:
-      # Note that test_id includes the iteration index (well, the batch index,
-      # at any rate), so this makes sense even if test_iter > 0.
-      return self.rerun_seed[test_id]
+    def get(self, test_id, test_iter):
+        """Get the seed to use for the given test and iteration"""
 
-    if self.fixed_seed is not None:
-      # Checked at argument parsing time
-      assert test_iter == 0
-      return self.fixed_seed
+        if test_id in self.rerun_seed:
+            # Note that test_id includes the iteration index (well, the batch
+            # index, at any rate), so this makes sense even if test_iter > 0.
+            return self.rerun_seed[test_id]
 
-    if self.start_seed is not None:
-      return self.start_seed + test_iter
+        if self.fixed_seed is not None:
+            # Checked at argument parsing time
+            assert test_iter == 0
+            return self.fixed_seed
 
-    # If the user didn't specify seeds in some way, we generate a random seed
-    # every time
-    return random.getrandbits(31)
+        if self.start_seed is not None:
+            return self.start_seed + test_iter
+
+        # If the user didn't specify seeds in some way, we generate a random
+        # seed every time
+        return random.getrandbits(31)
 
 
 def get_generator_cmd(simulator, simulator_yaml, cov, exp, debug_cmd):
-  """ Setup the compile and simulation command for the generator
+    """ Setup the compile and simulation command for the generator
 
-  Args:
-    simulator      : RTL/pyflow simulator used to run instruction generator
-    simulator_yaml : RTL/pyflow simulator configuration file in YAML format
-    cov            : Enable functional coverage
-    exp            : Use experimental version
-    debug_cmd      : Produce the debug cmd log without running
+    Args:
+      simulator      : RTL/pyflow simulator used to run instruction generator
+      simulator_yaml : RTL/pyflow simulator configuration file in YAML format
+      cov            : Enable functional coverage
+      exp            : Use experimental version
+      debug_cmd      : Produce the debug cmd log without running
 
-  Returns:
-    compile_cmd    : RTL/pyflow simulator command to compile the instruction
-                     generator
-    sim_cmd        : RTL/pyflow simulator command to run the instruction
-                     generator
-  """
-  logging.info("Processing simulator setup file : %s" % simulator_yaml)
-  yaml_data = read_yaml(simulator_yaml)
-  # Search for matched simulator
-  for entry in yaml_data:
-    if entry['tool'] == simulator:
-      logging.info("Found matching simulator: %s" % entry['tool'])
-      if simulator == "pyflow":
-        compile_cmd = ""
-      else:
-        compile_spec = entry['compile']
-        compile_cmd = compile_spec['cmd']
-        for i in range(len(compile_cmd)):
-          if ('cov_opts' in compile_spec) and cov:
-            compile_cmd[i] = re.sub('<cov_opts>', compile_spec['cov_opts'].rstrip(), compile_cmd[i])
-          else:
-            compile_cmd[i] = re.sub('<cov_opts>', '', compile_cmd[i])
-          if exp:
-            compile_cmd[i] += " +define+EXPERIMENTAL "
-      sim_cmd = entry['sim']['cmd']
-      if ('cov_opts' in entry['sim']) and cov:
-        sim_cmd = re.sub('<cov_opts>', entry['sim']['cov_opts'].rstrip(), sim_cmd)
-      else:
-        sim_cmd = re.sub('<cov_opts>', '', sim_cmd)
-      if 'env_var' in entry:
-        for env_var in entry['env_var'].split(','):
-          for i in range(len(compile_cmd)):
-            compile_cmd[i] = re.sub("<"+env_var+">", get_env_var(env_var, debug_cmd = debug_cmd),
-                                    compile_cmd[i])
-          sim_cmd = re.sub("<"+env_var+">", get_env_var(env_var, debug_cmd = debug_cmd), sim_cmd)
-      return compile_cmd, sim_cmd
-  logging.error("Cannot find simulator %0s" % simulator)
-  sys.exit(RET_FAIL)
+    Returns:
+      compile_cmd    : RTL/pyflow simulator command to compile the instruction
+                       generator
+      sim_cmd        : RTL/pyflow simulator command to run the instruction
+                       generator
+    """
+    logging.info("Processing simulator setup file : {}".format(simulator_yaml))
+    yaml_data = read_yaml(simulator_yaml)
+    # Search for matched simulator
+    for entry in yaml_data:
+        if entry['tool'] == simulator:
+            logging.info("Found matching simulator: {}".format(entry['tool']))
+            if simulator == "pyflow":
+                compile_cmd = ""
+            else:
+                compile_spec = entry['compile']
+                compile_cmd = compile_spec['cmd']
+                for i in range(len(compile_cmd)):
+                    if ('cov_opts' in compile_spec) and cov:
+                        compile_cmd[i] = re.sub('<cov_opts>', compile_spec[
+                            'cov_opts'].rstrip(), compile_cmd[i])
+                    else:
+                        compile_cmd[i] = re.sub('<cov_opts>', '',
+                                                compile_cmd[i])
+                    if exp:
+                        compile_cmd[i] += " +define+EXPERIMENTAL "
+            sim_cmd = entry['sim']['cmd']
+            if ('cov_opts' in entry['sim']) and cov:
+                sim_cmd = re.sub('<cov_opts>',
+                                 entry['sim']['cov_opts'].rstrip(), sim_cmd)
+            else:
+                sim_cmd = re.sub('<cov_opts>', '', sim_cmd)
+            if 'env_var' in entry:
+                for env_var in entry['env_var'].split(','):
+                    for i in range(len(compile_cmd)):
+                        compile_cmd[i] = re.sub(
+                            "<" + env_var + ">", get_env_var(env_var, debug_cmd=debug_cmd),
+                            compile_cmd[i])
+                    sim_cmd = re.sub(
+                        "<" + env_var + ">", get_env_var(env_var, debug_cmd=debug_cmd),
+                        sim_cmd)
+            return compile_cmd, sim_cmd
+    logging.error("Cannot find simulator {}".format(simulator))
+    sys.exit(RET_FAIL)
 
 
 def parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd):
-  """Parse ISS YAML to get the simulation command
+    """Parse ISS YAML to get the simulation command
 
-  Args:
-    iss         : target ISS used to look up in ISS YAML
-    iss_yaml    : ISS configuration file in YAML format
-    isa         : ISA variant passed to the ISS
-    setting_dir : Generator setting directory
-    debug_cmd   : Produce the debug cmd log without running
+    Args:
+      iss         : target ISS used to look up in ISS YAML
+      iss_yaml    : ISS configuration file in YAML format
+      isa         : ISA variant passed to the ISS
+      setting_dir : Generator setting directory
+      debug_cmd   : Produce the debug cmd log without running
 
-  Returns:
-    cmd         : ISS run command
-  """
-  logging.info("Processing ISS setup file : %s" % iss_yaml)
-  yaml_data = read_yaml(iss_yaml)
-  # Search for matched ISS
-  for entry in yaml_data:
-    if entry['iss'] == iss:
-      logging.info("Found matching ISS: %s" % entry['iss'])
-      cmd = entry['cmd'].rstrip()
-      cmd = re.sub("\<path_var\>", get_env_var(entry['path_var'], debug_cmd = debug_cmd), cmd)
-      m = re.search(r"rv(?P<xlen>[0-9]+?)(?P<variant>[a-z]+?)$", isa)
-      if m:
-        cmd = re.sub("\<xlen\>", m.group('xlen'), cmd)
-      else:
-        logging.error("Illegal ISA %0s" % isa)
-      if iss == "ovpsim":
-        cmd = re.sub("\<cfg_path\>", setting_dir, cmd)
-      elif iss == "whisper":
-        if m:
-          # TODO: Support u/s mode
-          variant = re.sub('g', 'imafd',  m.group('variant'))
-          cmd = re.sub("\<variant\>", variant, cmd)
-      else:
-        cmd = re.sub("\<variant\>", isa, cmd)
-      return cmd
-  logging.error("Cannot find ISS %0s" % iss)
-  sys.exit(RET_FAIL)
+    Returns:
+      cmd         : ISS run command
+    """
+    logging.info("Processing ISS setup file : {}".format(iss_yaml))
+    yaml_data = read_yaml(iss_yaml)
+    # Search for matched ISS
+    for entry in yaml_data:
+        if entry['iss'] == iss:
+            logging.info("Found matching ISS: {}".format(entry['iss']))
+            cmd = entry['cmd'].rstrip()
+            cmd = re.sub("\<path_var\>",
+                         get_env_var(entry['path_var'], debug_cmd=debug_cmd),
+                         cmd)
+            m = re.search(r"rv(?P<xlen>[0-9]+?)(?P<variant>[a-z]+?)$", isa)
+            if m:
+                cmd = re.sub("\<xlen\>", m.group('xlen'), cmd)
+            else:
+                logging.error("Illegal ISA {}".format(isa))
+            if iss == "ovpsim":
+                cmd = re.sub("\<cfg_path\>", setting_dir, cmd)
+            elif iss == "whisper":
+                if m:
+                    # TODO: Support u/s mode
+                    variant = re.sub('g', 'imafd', m.group('variant'))
+                    cmd = re.sub("\<variant\>", variant, cmd)
+            else:
+                cmd = re.sub("\<variant\>", isa, cmd)
+            return cmd
+    logging.error("Cannot find ISS {}".format(iss))
+    sys.exit(RET_FAIL)
 
 
 def get_iss_cmd(base_cmd, elf, log):
-  """Get the ISS simulation command
+    """Get the ISS simulation command
 
-  Args:
-    base_cmd : Original command template
-    elf      : ELF file to run ISS simualtion
-    log      : ISS simulation log name
+    Args:
+      base_cmd : Original command template
+      elf      : ELF file to run ISS simualtion
+      log      : ISS simulation log name
 
-  Returns:
-    cmd      : Command for ISS simulation
-  """
-  cmd = re.sub("\<elf\>", elf, base_cmd)
-  cmd += (" &> %s" % log)
-  return cmd
+    Returns:
+      cmd      : Command for ISS simulation
+    """
+    cmd = re.sub("\<elf\>", elf, base_cmd)
+    cmd += (" &> {}".format(log))
+    return cmd
 
 
 def do_compile(compile_cmd, test_list, core_setting_dir, cwd, ext_dir,
                cmp_opts, output_dir, debug_cmd, lsf_cmd):
-  """Compile the instruction generator
+    """Compile the instruction generator
 
-  Args:
-    compile_cmd         : Compile command for the generator
-    test_list           : List of assembly programs to be compiled
-    core_setting_dir    : Path for riscv_core_setting.sv
-    cwd                 : Filesystem path to RISCV-DV repo
-    ext_dir             : User extension directory
-    cmd_opts            : Compile options for the generator
-    output_dir          : Output directory of the ELF files
-    debug_cmd           : Produce the debug cmd log without running
-    lsf_cmd             : LSF command used to run the instruction generator
-  """
-  if (not((len(test_list) == 1) and (test_list[0]['test'] == 'riscv_csr_test'))):
-    logging.info("Building RISC-V instruction generator")
-    for cmd in compile_cmd:
-      cmd = re.sub("<out>", os.path.abspath(output_dir), cmd)
-      cmd = re.sub("<setting>", core_setting_dir, cmd)
-      if ext_dir == "":
-        cmd = re.sub("<user_extension>", "<cwd>/user_extension", cmd)
-      else:
-        cmd = re.sub("<user_extension>", ext_dir, cmd)
-      cmd = re.sub("<cwd>", cwd, cmd)
-      cmd = re.sub("<cmp_opts>", cmp_opts, cmd)
-      if lsf_cmd:
-        cmd = lsf_cmd + " " + cmd
-        run_parallel_cmd([cmd], debug_cmd = debug_cmd)
-      else:
-        logging.debug("Compile command: %s" % cmd)
-        run_cmd(cmd, debug_cmd = debug_cmd)
+    Args:
+      compile_cmd         : Compile command for the generator
+      test_list           : List of assembly programs to be compiled
+      core_setting_dir    : Path for riscv_core_setting.sv
+      cwd                 : Filesystem path to RISCV-DV repo
+      ext_dir             : User extension directory
+      cmp_opts            : Compile options for the generator
+      output_dir          : Output directory of the ELF files
+      debug_cmd           : Produce the debug cmd log without running
+      lsf_cmd             : LSF command used to run the instruction generator
+    """
+    if not ((len(test_list) == 1) and (
+            test_list[0]['test'] == 'riscv_csr_test')):
+        logging.info("Building RISC-V instruction generator")
+        for cmd in compile_cmd:
+            cmd = re.sub("<out>", os.path.abspath(output_dir), cmd)
+            cmd = re.sub("<setting>", core_setting_dir, cmd)
+            if ext_dir == "":
+                cmd = re.sub("<user_extension>", "<cwd>/user_extension", cmd)
+            else:
+                cmd = re.sub("<user_extension>", ext_dir, cmd)
+            cmd = re.sub("<cwd>", cwd, cmd)
+            cmd = re.sub("<cmp_opts>", cmp_opts, cmd)
+            if lsf_cmd:
+                cmd = lsf_cmd + " " + cmd
+                run_parallel_cmd([cmd], debug_cmd=debug_cmd)
+            else:
+                logging.debug("Compile command: {}".format(cmd))
+                run_cmd(cmd, debug_cmd=debug_cmd)
 
 
 def run_csr_test(cmd_list, cwd, csr_file, isa, iterations, lsf_cmd,
                  end_signature_addr, timeout_s, output_dir, debug_cmd):
-  """Run CSR test
+    """Run CSR test
      It calls a separate python script to generate directed CSR test code,
      located at scripts/gen_csr_test.py.
-  """
-  cmd = "python3 " + cwd + "/scripts/gen_csr_test.py" + \
-        (" --csr_file %s" % csr_file) + \
-        (" --xlen %s" % re.search(r"(?P<xlen>[0-9]+)", isa).group("xlen")) + \
-        (" --iterations %i" % iterations) + \
-        (" --out %s/asm_tests" % output_dir) + \
-        (" --end_signature_addr %s" % end_signature_addr)
-  if lsf_cmd:
-    cmd_list.append(cmd)
-  else:
-    run_cmd(cmd, timeout_s, debug_cmd = debug_cmd)
+    """
+    cmd = "python3 " + cwd + "/scripts/gen_csr_test.py" + \
+          (" --csr_file {}".format(csr_file)) + \
+          (" --xlen {}".format(
+              re.search(r"(?P<xlen>[0-9]+)", isa).group("xlen"))) + \
+          (" --iterations {}".format(iterations)) + \
+          (" --out {}/asm_tests".format(output_dir)) + \
+          (" --end_signature_addr {}".format(end_signature_addr))
+    if lsf_cmd:
+        cmd_list.append(cmd)
+    else:
+        run_cmd(cmd, timeout_s, debug_cmd=debug_cmd)
 
 
-def do_simulate(sim_cmd, simulator, test_list, cwd, sim_opts, seed_gen, csr_file,
+def do_simulate(sim_cmd, simulator, test_list, cwd, sim_opts, seed_gen,
+                csr_file,
                 isa, end_signature_addr, lsf_cmd, timeout_s, log_suffix,
                 batch_size, output_dir, verbose, check_return_code, debug_cmd):
-  """Run  the instruction generator
+    """Run  the instruction generator
 
-  Args:
-    sim_cmd               : Simulate command for the generator
-    simulator             : simulator used to run instruction generator
-    test_list             : List of assembly programs to be compiled
-    cwd                   : Filesystem path to RISCV-DV repo
-    sim_opts              : Simulation options for the generator
-    seed_gen              : A SeedGen seed generator
-    csr_file              : YAML file containing description of all CSRs
-    isa                   : Processor supported ISA subset
-    end_signature_addr    : Address that tests will write pass/fail signature to at end of test
-    lsf_cmd               : LSF command used to run the instruction generator
-    timeout_s             : Timeout limit in seconds
-    log_suffix            : Simulation log file name suffix
-    batch_size            : Number of tests to generate per run
-    output_dir            : Output directory of the ELF files
-    check_return_code     : Check return code of the command
-    debug_cmd             : Produce the debug cmd log without running
-  """
-  cmd_list = []
-  sim_cmd = re.sub("<out>", os.path.abspath(output_dir), sim_cmd)
-  sim_cmd = re.sub("<cwd>", cwd, sim_cmd)
-  sim_cmd = re.sub("<sim_opts>", sim_opts, sim_cmd)
+    Args:
+      sim_cmd               : Simulate command for the generator
+      simulator             : simulator used to run instruction generator
+      test_list             : List of assembly programs to be compiled
+      cwd                   : Filesystem path to RISCV-DV repo
+      sim_opts              : Simulation options for the generator
+      seed_gen              : A SeedGen seed generator
+      csr_file              : YAML file containing description of all CSRs
+      isa                   : Processor supported ISA subset
+      end_signature_addr    : Address that tests will write pass/fail signature to at end of test
+      lsf_cmd               : LSF command used to run the instruction generator
+      timeout_s             : Timeout limit in seconds
+      log_suffix            : Simulation log file name suffix
+      batch_size            : Number of tests to generate per run
+      output_dir            : Output directory of the ELF files
+      verbose               : Verbose logging
+      check_return_code     : Check return code of the command
+      debug_cmd             : Produce the debug cmd log without running
+    """
+    cmd_list = []
+    sim_cmd = re.sub("<out>", os.path.abspath(output_dir), sim_cmd)
+    sim_cmd = re.sub("<cwd>", cwd, sim_cmd)
+    sim_cmd = re.sub("<sim_opts>", sim_opts, sim_cmd)
 
-  logging.info("Running RISC-V instruction generator")
-  sim_seed = {}
-  for test in test_list:
-    iterations = test['iterations']
-    logging.info("Generating %d %s" % (iterations, test['test']))
-    if iterations > 0:
-      # Running a CSR test
-      if test['test'] == 'riscv_csr_test':
-        run_csr_test(cmd_list, cwd, csr_file, isa, iterations, lsf_cmd,
-                     end_signature_addr, timeout_s, output_dir, debug_cmd)
-      else:
-        batch_cnt = 1
-        if batch_size > 0:
-          batch_cnt = int((iterations + batch_size - 1)  / batch_size)
-        logging.info("Running %s with %0d batches" % (test['test'], batch_cnt))
-        for i in range(0, batch_cnt):
-          test_id = '%0s_%0d' % (test['test'], i)
-          rand_seed = seed_gen.get(test_id, i * batch_cnt)
-          if i < batch_cnt - 1:
-            test_cnt = batch_size
-          else:
-            test_cnt = iterations - i * batch_size
-          if simulator == "pyflow":
-            sim_cmd = re.sub("<test_name>", test['gen_test'], sim_cmd)
-            cmd = lsf_cmd + " " + sim_cmd.rstrip() + \
-                  (" --num_of_tests=%s" % test_cnt) + \
-                  (" --start_idx=%i" % (i * batch_size)) + \
-                  (" --asm_file_name=%s/asm_tests/%s" % (output_dir, test['test'])) + \
-                  (" --log_file_name=%s/sim_%s_%i%s.log " % (output_dir,
-                                                            test['test'], i, log_suffix))
-          else:
-            cmd = lsf_cmd + " " + sim_cmd.rstrip() + \
-                  (" +UVM_TESTNAME=%s " % test['gen_test']) + \
-                  (" +num_of_tests=%i " % test_cnt) + \
-                  (" +start_idx=%d " % (i*batch_size)) + \
-                  (" +asm_file_name=%s/asm_tests/%s " % (output_dir, test['test'])) + \
-                  (" -l %s/sim_%s_%d%s.log " % (output_dir, test['test'], i, log_suffix))
-          if verbose and simulator != "pyflow":
-            cmd += "+UVM_VERBOSITY=UVM_HIGH "
-          cmd = re.sub("<seed>", str(rand_seed), cmd)
-          cmd = re.sub("<test_id>", test_id, cmd)
-          sim_seed[test_id] = str(rand_seed)
-          if "gen_opts" in test:
-            if simulator == "pyflow":
-              test['gen_opts'] = re.sub("\+", "--",test['gen_opts'])
-              cmd += test['gen_opts']
+    logging.info("Running RISC-V instruction generator")
+    sim_seed = {}
+    for test in test_list:
+        iterations = test['iterations']
+        logging.info("Generating {} {}".format(iterations, test['test']))
+        if iterations > 0:
+            # Running a CSR test
+            if test['test'] == 'riscv_csr_test':
+                run_csr_test(cmd_list, cwd, csr_file, isa, iterations, lsf_cmd,
+                             end_signature_addr, timeout_s, output_dir,
+                             debug_cmd)
             else:
-              cmd += test['gen_opts']
-          if not re.search("c", isa):
-            cmd += "+disable_compressed_instr=1 ";
-          if lsf_cmd:
-            cmd_list.append(cmd)
-          else:
-            logging.info("Running %s, batch %0d/%0d, test_cnt:%0d" %
-                         (test['test'], i+1, batch_cnt, test_cnt))
-            run_cmd(cmd, timeout_s, check_return_code = check_return_code, debug_cmd = debug_cmd)
-  if sim_seed:
-    with open(('%s/seed.yaml' % os.path.abspath(output_dir)) , 'w') as outfile:
-      yaml.dump(sim_seed, outfile, default_flow_style=False)
-  if lsf_cmd:
-    run_parallel_cmd(cmd_list, timeout_s, check_return_code = check_return_code,
-                     debug_cmd = debug_cmd)
+                batch_cnt = 1
+                if batch_size > 0:
+                    batch_cnt = int((iterations + batch_size - 1) / batch_size)
+                logging.info(
+                    "Running {} with {} batches".format(test['test'],
+                                                        batch_cnt))
+                for i in range(0, batch_cnt):
+                    test_id = '{}_{}'.format(test['test'], i)
+                    rand_seed = seed_gen.get(test_id, i * batch_cnt)
+                    if i < batch_cnt - 1:
+                        test_cnt = batch_size
+                    else:
+                        test_cnt = iterations - i * batch_size
+                    if simulator == "pyflow":
+                        sim_cmd = re.sub("<test_name>", test['gen_test'],
+                                         sim_cmd)
+                        cmd = lsf_cmd + " " + sim_cmd.rstrip() + \
+                              (" --num_of_tests={}".format(test_cnt)) + \
+                              (" --start_idx={}".format(i * batch_size)) + \
+                              (" --asm_file_name={}/asm_tests/{}".format(
+                                  output_dir, test['test'])) + \
+                              (" --log_file_name={}/sim_{}_{}{}.log ".format(
+                                  output_dir,
+                                  test['test'], i, log_suffix))
+                    else:
+                        cmd = lsf_cmd + " " + sim_cmd.rstrip() + \
+                              (" +UVM_TESTNAME={} ".format(test['gen_test'])) + \
+                              (" +num_of_tests={} ".format(test_cnt)) + \
+                              (" +start_idx={} ".format(i * batch_size)) + \
+                              (" +asm_file_name={}/asm_tests/{} ".format(
+                                  output_dir, test['test'])) + \
+                              (" -l {}/sim_{}_{}{}.log ".format(
+                                  output_dir, test['test'], i, log_suffix))
+                    if verbose and simulator != "pyflow":
+                        cmd += "+UVM_VERBOSITY=UVM_HIGH "
+                    cmd = re.sub("<seed>", str(rand_seed), cmd)
+                    cmd = re.sub("<test_id>", test_id, cmd)
+                    sim_seed[test_id] = str(rand_seed)
+                    if "gen_opts" in test:
+                        if simulator == "pyflow":
+                            test['gen_opts'] = re.sub("\+", "--",
+                                                      test['gen_opts'])
+                            cmd += test['gen_opts']
+                        else:
+                            cmd += test['gen_opts']
+                    if not re.search("c", isa):
+                        cmd += "+disable_compressed_instr=1 "
+                    if lsf_cmd:
+                        cmd_list.append(cmd)
+                    else:
+                        logging.info(
+                            "Running {}, batch {}/{}, test_cnt:{}".format(
+                                test['test'], i + 1, batch_cnt, test_cnt))
+                        run_cmd(cmd, timeout_s,
+                                check_return_code=check_return_code,
+                                debug_cmd=debug_cmd)
+    if sim_seed:
+        with open(('{}/seed.yaml'.format(os.path.abspath(output_dir))),
+                  'w') as outfile:
+            yaml.dump(sim_seed, outfile, default_flow_style=False)
+    if lsf_cmd:
+        run_parallel_cmd(cmd_list, timeout_s,
+                         check_return_code=check_return_code,
+                         debug_cmd=debug_cmd)
 
 
 def gen(test_list, argv, output_dir, cwd):
-  """Run the instruction generator
+    """Run the instruction generator
 
-  Args:
-    test_list             : List of assembly programs to be compiled
-    argv                  : Configuration arguments
-    output_dir            : Output directory of the ELF files
-    cwd                   : Filesystem path to RISCV-DV repo
-  """
-  check_return_code = True
-  if argv.simulator == "ius":
-    # Incisive return non-zero return code even test passes
-    check_return_code = False
-    logging.debug("Disable return_code checking for %s" % argv.simulator)
-  # Mutually exclusive options between compile_only and sim_only
-  if argv.co and argv.so:
-    logging.error("argument -co is not allowed with argument -so")
-    return
-  if ((argv.co == 0) and (len(test_list) == 0)):
-    return
-  # Setup the compile and simulation command for the generator
-  compile_cmd = []
-  sim_cmd = ""
-  compile_cmd, sim_cmd = get_generator_cmd(argv.simulator, argv.simulator_yaml, argv.cov,
-                                           argv.exp, argv.debug);
-  # Compile the instruction generator
-  # No compilation process in pyflow simulator
-  if not argv.so:
-    do_compile(compile_cmd, test_list, argv.core_setting_dir, cwd, argv.user_extension_dir,
-               argv.cmp_opts, output_dir, argv.debug, argv.lsf_cmd)
-  # Run the instruction generator
-  if not argv.co:
-    seed_gen = SeedGen(argv.start_seed, argv.seed, argv.seed_yaml)
-    do_simulate(sim_cmd, argv.simulator, test_list, cwd, argv.sim_opts,seed_gen,
-                argv.csr_yaml,argv.isa, argv.end_signature_addr, argv.lsf_cmd,
-                argv.gen_timeout, argv.log_suffix,argv.batch_size, output_dir,
-                argv.verbose, check_return_code, argv.debug)
+    Args:
+      test_list             : List of assembly programs to be compiled
+      argv                  : Configuration arguments
+      output_dir            : Output directory of the ELF files
+      cwd                   : Filesystem path to RISCV-DV repo
+    """
+    check_return_code = True
+    if argv.simulator == "ius":
+        # Incisive return non-zero return code even test passes
+        check_return_code = False
+        logging.debug(
+            "Disable return_code checking for {}".format(argv.simulator))
+    # Mutually exclusive options between compile_only and sim_only
+    if argv.co and argv.so:
+        logging.error("argument -co is not allowed with argument -so")
+        return
+    if argv.co == 0 and len(test_list) == 0:
+        return
+    # Setup the compile and simulation command for the generator
+    compile_cmd, sim_cmd = get_generator_cmd(argv.simulator,
+                                             argv.simulator_yaml, argv.cov,
+                                             argv.exp, argv.debug)
+    # Compile the instruction generator
+    # No compilation process in pyflow simulator
+    if not argv.so:
+        do_compile(compile_cmd, test_list, argv.core_setting_dir, cwd,
+                   argv.user_extension_dir,
+                   argv.cmp_opts, output_dir, argv.debug, argv.lsf_cmd)
+    # Run the instruction generator
+    if not argv.co:
+        seed_gen = SeedGen(argv.start_seed, argv.seed, argv.seed_yaml)
+        do_simulate(sim_cmd, argv.simulator, test_list, cwd, argv.sim_opts,
+                    seed_gen,
+                    argv.csr_yaml, argv.isa, argv.end_signature_addr,
+                    argv.lsf_cmd,
+                    argv.gen_timeout, argv.log_suffix, argv.batch_size,
+                    output_dir,
+                    argv.verbose, check_return_code, argv.debug)
 
 
 def gcc_compile(test_list, output_dir, isa, mabi, opts, debug_cmd):
-  """Use riscv gcc toolchain to compile the assembly program
+    """Use riscv gcc toolchain to compile the assembly program
 
-  Args:
-    test_list  : List of assembly programs to be compiled
-    output_dir : Output directory of the ELF files
-    isa        : ISA variant passed to GCC
-    mabi       : MABI variant passed to GCC
-    debug_cmd  : Produce the debug cmd log without running
-  """
-  cwd = os.path.dirname(os.path.realpath(__file__))
-  for test in test_list:
-    for i in range(0, test['iterations']):
-      if 'no_gcc' in test and test['no_gcc'] == 1:
-        continue
-      prefix = ("%s/asm_tests/%s_%d" % (output_dir, test['test'], i))
-      asm = prefix + ".S"
-      elf = prefix + ".o"
-      binary = prefix + ".bin"
-      test_isa = isa
-      if not os.path.isfile(asm) and not debug_cmd:
-        logging.error("Cannot find assembly test: %s\n", asm)
-        sys.exit(RET_FAIL)
-      # gcc comilation
-      cmd = ("%s -static -mcmodel=medany \
+    Args:
+      test_list  : List of assembly programs to be compiled
+      output_dir : Output directory of the ELF files
+      isa        : ISA variant passed to GCC
+      mabi       : MABI variant passed to GCC
+      debug_cmd  : Produce the debug cmd log without running
+    """
+    cwd = os.path.dirname(os.path.realpath(__file__))
+    for test in test_list:
+        for i in range(0, test['iterations']):
+            if 'no_gcc' in test and test['no_gcc'] == 1:
+                continue
+            prefix = ("{}/asm_tests/{}_{}".format(output_dir, test['test'], i))
+            asm = prefix + ".S"
+            elf = prefix + ".o"
+            binary = prefix + ".bin"
+            test_isa = isa
+            if not os.path.isfile(asm) and not debug_cmd:
+                logging.error("Cannot find assembly test: {}\n".format(asm))
+                sys.exit(RET_FAIL)
+            # gcc compilation
+            cmd = ("{} -static -mcmodel=medany \
              -fvisibility=hidden -nostdlib \
-             -nostartfiles %s \
-             -I%s/user_extension \
-             -T%s/scripts/link.ld %s -o %s " % \
-             (get_env_var("RISCV_GCC", debug_cmd = debug_cmd), asm, cwd, cwd, opts, elf))
-      if 'gcc_opts' in test:
-        cmd += test['gcc_opts']
-      if 'gen_opts' in test:
-        # Disable compressed instruction
-        if re.search('disable_compressed_instr', test['gen_opts']):
-          test_isa = re.sub("c",  "", test_isa)
-      # If march/mabi is not defined in the test gcc_opts, use the default
-      # setting from the command line.
-      if not re.search('march', cmd):
-        cmd += (" -march=%s" % test_isa)
-      if not re.search('mabi', cmd):
-        cmd += (" -mabi=%s" % mabi)
-      logging.info("Compiling %s" % asm)
-      run_cmd_output(cmd.split(), debug_cmd = debug_cmd)
-      # Convert the ELF to plain binary, used in RTL sim
-      logging.info("Converting to %s" % binary)
-      cmd = ("%s -O binary %s %s" % (get_env_var("RISCV_OBJCOPY", debug_cmd = debug_cmd),
-             elf, binary))
-      run_cmd_output(cmd.split(), debug_cmd = debug_cmd)
+             -nostartfiles {} \
+             -I{}/user_extension \
+             -T{}/scripts/link.ld {} -o {} ".format(
+                get_env_var("RISCV_GCC", debug_cmd=debug_cmd), asm, cwd,
+                cwd, opts, elf))
+            if 'gcc_opts' in test:
+                cmd += test['gcc_opts']
+            if 'gen_opts' in test:
+                # Disable compressed instruction
+                if re.search('disable_compressed_instr', test['gen_opts']):
+                    test_isa = re.sub("c", "", test_isa)
+            # If march/mabi is not defined in the test gcc_opts, use the default
+            # setting from the command line.
+            if not re.search('march', cmd):
+                cmd += (" -march={}".format(test_isa))
+            if not re.search('mabi', cmd):
+                cmd += (" -mabi={}".format(mabi))
+            logging.info("Compiling {}".format(asm))
+            run_cmd_output(cmd.split(), debug_cmd=debug_cmd)
+            # Convert the ELF to plain binary, used in RTL sim
+            logging.info("Converting to {}".format(binary))
+            cmd = ("{} -O binary {} {}".format(
+                get_env_var("RISCV_OBJCOPY", debug_cmd=debug_cmd), elf, binary))
+            run_cmd_output(cmd.split(), debug_cmd=debug_cmd)
 
 
 def run_assembly(asm_test, iss_yaml, isa, mabi, gcc_opts, iss_opts, output_dir,
                  setting_dir, debug_cmd):
-  """Run a directed assembly test with ISS
+    """Run a directed assembly test with ISS
 
-  Args:
-    asm_test    : Assembly test file
-    iss_yaml    : ISS configuration file in YAML format
-    isa         : ISA variant passed to the ISS
-    mabi        : MABI variant passed to GCC
-    gcc_opts    : User-defined options for GCC compilation
-    iss_opts    : Instruction set simulators
-    output_dir  : Output directory of compiled test files
-    setting_dir : Generator setting directory
-    debug_cmd   : Produce the debug cmd log without running
-  """
-  if not asm_test.endswith(".S"):
-    logging.error("%s is not an assembly .S file" % asm_test)
-    return
-  cwd = os.path.dirname(os.path.realpath(__file__))
-  asm_test = os.path.expanduser(asm_test)
-  report = ("%s/iss_regr.log" % output_dir).rstrip()
-  asm = re.sub(r"^.*\/", "", asm_test)
-  asm = re.sub(r"\.S$", "", asm)
-  prefix = ("%s/directed_asm_tests/%s"  % (output_dir, asm))
-  elf = prefix + ".o"
-  binary = prefix + ".bin"
-  iss_list = iss_opts.split(",")
-  run_cmd("mkdir -p %s/directed_asm_tests" % output_dir)
-  logging.info("Compiling assembly test : %s" % asm_test)
+    Args:
+      asm_test    : Assembly test file
+      iss_yaml    : ISS configuration file in YAML format
+      isa         : ISA variant passed to the ISS
+      mabi        : MABI variant passed to GCC
+      gcc_opts    : User-defined options for GCC compilation
+      iss_opts    : Instruction set simulators
+      output_dir  : Output directory of compiled test files
+      setting_dir : Generator setting directory
+      debug_cmd   : Produce the debug cmd log without running
+    """
+    if not asm_test.endswith(".S"):
+        logging.error("{} is not an assembly .S file".format(asm_test))
+        return
+    cwd = os.path.dirname(os.path.realpath(__file__))
+    asm_test = os.path.expanduser(asm_test)
+    report = ("{}/iss_regr.log".format(output_dir)).rstrip()
+    asm = re.sub(r"^.*\/", "", asm_test)
+    asm = re.sub(r"\.S$", "", asm)
+    prefix = ("{}/directed_asm_tests/{}".format(output_dir, asm))
+    elf = prefix + ".o"
+    binary = prefix + ".bin"
+    iss_list = iss_opts.split(",")
+    run_cmd("mkdir -p {}/directed_asm_tests".format(output_dir))
+    logging.info("Compiling assembly test : {}".format(asm_test))
 
-  # gcc compilation
-  cmd = ("%s -static -mcmodel=medany \
+    # gcc compilation
+    cmd = ("{} -static -mcmodel=medany \
          -fvisibility=hidden -nostdlib \
-         -nostartfiles %s \
-         -I%s/user_extension \
-         -T%s/scripts/link.ld %s -o %s " % \
-         (get_env_var("RISCV_GCC", debug_cmd = debug_cmd), asm_test, cwd,
-                      cwd, gcc_opts, elf))
-  cmd += (" -march=%s" % isa)
-  cmd += (" -mabi=%s" % mabi)
-  run_cmd_output(cmd.split(), debug_cmd = debug_cmd)
-  # Convert the ELF to plain binary, used in RTL sim
-  logging.info("Converting to %s" % binary)
-  cmd = ("%s -O binary %s %s" % (get_env_var("RISCV_OBJCOPY", debug_cmd = debug_cmd), elf, binary))
-  run_cmd_output(cmd.split(), debug_cmd = debug_cmd)
-  log_list = []
-  # ISS simulation
-  for iss in iss_list:
-    run_cmd("mkdir -p %s/%s_sim" % (output_dir, iss))
-    log = ("%s/%s_sim/%s.log" % (output_dir, iss, asm))
-    log_list.append(log)
-    base_cmd = parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd)
-    logging.info("[%0s] Running ISS simulation: %s" % (iss, elf))
-    cmd = get_iss_cmd(base_cmd, elf, log)
-    run_cmd(cmd, 10, debug_cmd = debug_cmd)
-    logging.info("[%0s] Running ISS simulation: %s ...done" % (iss, elf))
-  if len(iss_list) == 2:
-    compare_iss_log(iss_list, log_list, report)
+         -nostartfiles {} \
+         -I{}/user_extension \
+         -T{}/scripts/link.ld {} -o {} ".format(
+        get_env_var("RISCV_GCC", debug_cmd=debug_cmd), asm_test, cwd,
+        cwd, gcc_opts, elf))
+    cmd += (" -march={}".format(isa))
+    cmd += (" -mabi={}".format(mabi))
+    run_cmd_output(cmd.split(), debug_cmd=debug_cmd)
+    # Convert the ELF to plain binary, used in RTL sim
+    logging.info("Converting to {}".format(binary))
+    cmd = ("{} -O binary {} {}".format(
+        get_env_var("RISCV_OBJCOPY", debug_cmd=debug_cmd), elf, binary))
+    run_cmd_output(cmd.split(), debug_cmd=debug_cmd)
+    log_list = []
+    # ISS simulation
+    for iss in iss_list:
+        run_cmd("mkdir -p {}/{}_sim".format(output_dir, iss))
+        log = ("{}/{}_sim/{}.log".format(output_dir, iss, asm))
+        log_list.append(log)
+        base_cmd = parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd)
+        logging.info("[{}] Running ISS simulation: {}".format(iss, elf))
+        cmd = get_iss_cmd(base_cmd, elf, log)
+        run_cmd(cmd, 10, debug_cmd=debug_cmd)
+        logging.info("[{}] Running ISS simulation: {} ...done".format(iss, elf))
+    if len(iss_list) == 2:
+        compare_iss_log(iss_list, log_list, report)
 
 
 def run_assembly_from_dir(asm_test_dir, iss_yaml, isa, mabi, gcc_opts, iss,
                           output_dir, setting_dir, debug_cmd):
-  """Run a directed assembly test from a directory with spike
+    """Run a directed assembly test from a directory with spike
 
-  Args:
-    asm_test_dir    : Assembly test file directory
-    iss_yaml        : ISS configuration file in YAML format
-    isa             : ISA variant passed to the ISS
-    mabi            : MABI variant passed to GCC
-    gcc_opts        : User-defined options for GCC compilation
-    iss             : Instruction set simulators
-    output_dir      : Output directory of compiled test files
-    setting_dir     : Generator setting directory
-    debug_cmd       : Produce the debug cmd log without running
-  """
-  result = run_cmd("find %s -name \"*.S\"" % asm_test_dir)
-  if result:
-    asm_list = result.splitlines()
-    logging.info("Found %0d assembly tests under %s" %
-                 (len(asm_list), asm_test_dir))
-    for asm_file in asm_list:
-      run_assembly(asm_file, iss_yaml, isa, mabi, gcc_opts, iss, output_dir,
-                   setting_dir, debug_cmd)
-      if "," in iss:
-        report = ("%s/iss_regr.log" % output_dir).rstrip()
-        save_regr_report(report)
-  else:
-    logging.error("No assembly test(*.S) found under %s" % asm_test_dir)
+    Args:
+      asm_test_dir    : Assembly test file directory
+      iss_yaml        : ISS configuration file in YAML format
+      isa             : ISA variant passed to the ISS
+      mabi            : MABI variant passed to GCC
+      gcc_opts        : User-defined options for GCC compilation
+      iss             : Instruction set simulators
+      output_dir      : Output directory of compiled test files
+      setting_dir     : Generator setting directory
+      debug_cmd       : Produce the debug cmd log without running
+    """
+    result = run_cmd("find {} -name \"*.S\"".format(asm_test_dir))
+    if result:
+        asm_list = result.splitlines()
+        logging.info("Found {} assembly tests under {}".format(
+            len(asm_list), asm_test_dir))
+        for asm_file in asm_list:
+            run_assembly(asm_file, iss_yaml, isa, mabi, gcc_opts, iss,
+                         output_dir,
+                         setting_dir, debug_cmd)
+            if "," in iss:
+                report = ("{}/iss_regr.log".format(output_dir)).rstrip()
+                save_regr_report(report)
+    else:
+        logging.error(
+            "No assembly test(*.S) found under {}".format(asm_test_dir))
 
 
 def run_c(c_test, iss_yaml, isa, mabi, gcc_opts, iss_opts, output_dir,
           setting_dir, debug_cmd):
-  """Run a directed c test with ISS
+    """Run a directed c test with ISS
 
-  Args:
-    c_test      : C test file
-    iss_yaml    : ISS configuration file in YAML format
-    isa         : ISA variant passed to the ISS
-    mabi        : MABI variant passed to GCC
-    gcc_opts    : User-defined options for GCC compilation
-    iss_opts    : Instruction set simulators
-    output_dir  : Output directory of compiled test files
-    setting_dir : Generator setting directory
-    debug_cmd   : Produce the debug cmd log without running
-  """
-  if not c_test.endswith(".c"):
-    logging.error("%s is not a .c file" % c_test)
-    return
-  cwd = os.path.dirname(os.path.realpath(__file__))
-  c_test = os.path.expanduser(c_test)
-  report = ("%s/iss_regr.log" % output_dir).rstrip()
-  c = re.sub(r"^.*\/", "", c_test)
-  c = re.sub(r"\.c$", "", c)
-  prefix = ("%s/directed_c_tests/%s"  % (output_dir, c))
-  elf = prefix + ".o"
-  binary = prefix + ".bin"
-  iss_list = iss_opts.split(",")
-  run_cmd("mkdir -p %s/directed_c_tests" % output_dir)
-  logging.info("Compiling c test : %s" % c_test)
+    Args:
+      c_test      : C test file
+      iss_yaml    : ISS configuration file in YAML format
+      isa         : ISA variant passed to the ISS
+      mabi        : MABI variant passed to GCC
+      gcc_opts    : User-defined options for GCC compilation
+      iss_opts    : Instruction set simulators
+      output_dir  : Output directory of compiled test files
+      setting_dir : Generator setting directory
+      debug_cmd   : Produce the debug cmd log without running
+    """
+    if not c_test.endswith(".c"):
+        logging.error("{} is not a .c file".format(c_test))
+        return
+    cwd = os.path.dirname(os.path.realpath(__file__))
+    c_test = os.path.expanduser(c_test)
+    report = ("{}/iss_regr.log".format(output_dir)).rstrip()
+    c = re.sub(r"^.*\/", "", c_test)
+    c = re.sub(r"\.c$", "", c)
+    prefix = ("{}/directed_c_tests/{}".format(output_dir, c))
+    elf = prefix + ".o"
+    binary = prefix + ".bin"
+    iss_list = iss_opts.split(",")
+    run_cmd("mkdir -p {}/directed_c_tests".format(output_dir))
+    logging.info("Compiling c test : {}".format(c_test))
 
-  # gcc compilation
-  cmd = ("%s -mcmodel=medany -nostdlib \
-         -nostartfiles %s \
-         -I%s/user_extension \
-         -T%s/scripts/link.ld %s -o %s " % \
-         (get_env_var("RISCV_GCC", debug_cmd = debug_cmd), c_test, cwd,
-                      cwd, gcc_opts, elf))
-  cmd += (" -march=%s" % isa)
-  cmd += (" -mabi=%s" % mabi)
-  run_cmd_output(cmd.split(), debug_cmd = debug_cmd)
-  # Convert the ELF to plain binary, used in RTL sim
-  logging.info("Converting to %s" % binary)
-  cmd = ("%s -O binary %s %s" % (get_env_var("RISCV_OBJCOPY", debug_cmd = debug_cmd), elf, binary))
-  run_cmd_output(cmd.split(), debug_cmd = debug_cmd)
-  log_list = []
-  # ISS simulation
-  for iss in iss_list:
-    run_cmd("mkdir -p %s/%s_sim" % (output_dir, iss))
-    log = ("%s/%s_sim/%s.log" % (output_dir, iss, c))
-    log_list.append(log)
-    base_cmd = parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd)
-    logging.info("[%0s] Running ISS simulation: %s" % (iss, elf))
-    cmd = get_iss_cmd(base_cmd, elf, log)
-    run_cmd(cmd, 10, debug_cmd = debug_cmd)
-    logging.info("[%0s] Running ISS simulation: %s ...done" % (iss, elf))
-  if len(iss_list) == 2:
-    compare_iss_log(iss_list, log_list, report)
+    # gcc compilation
+    cmd = ("{} -mcmodel=medany -nostdlib \
+         -nostartfiles {} \
+         -I{}/user_extension \
+         -T{}/scripts/link.ld {} -o {} ".format(
+        get_env_var("RISCV_GCC", debug_cmd=debug_cmd), c_test, cwd,
+        cwd, gcc_opts, elf))
+    cmd += (" -march={}".format(isa))
+    cmd += (" -mabi={}".format(mabi))
+    run_cmd_output(cmd.split(), debug_cmd=debug_cmd)
+    # Convert the ELF to plain binary, used in RTL sim
+    logging.info("Converting to {}".format(binary))
+    cmd = ("{} -O binary {} {}".format(
+        get_env_var("RISCV_OBJCOPY", debug_cmd=debug_cmd), elf, binary))
+    run_cmd_output(cmd.split(), debug_cmd=debug_cmd)
+    log_list = []
+    # ISS simulation
+    for iss in iss_list:
+        run_cmd("mkdir -p {}/{}_sim".format(output_dir, iss))
+        log = ("{}/{}_sim/{}.log".format(output_dir, iss, c))
+        log_list.append(log)
+        base_cmd = parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd)
+        logging.info("[{}] Running ISS simulation: {}".format(iss, elf))
+        cmd = get_iss_cmd(base_cmd, elf, log)
+        run_cmd(cmd, 10, debug_cmd=debug_cmd)
+        logging.info("[{}] Running ISS simulation: {} ...done".format(iss, elf))
+    if len(iss_list) == 2:
+        compare_iss_log(iss_list, log_list, report)
 
 
 def run_c_from_dir(c_test_dir, iss_yaml, isa, mabi, gcc_opts, iss,
                    output_dir, setting_dir, debug_cmd):
-  """Run a directed c test from a directory with spike
+    """Run a directed c test from a directory with spike
 
-  Args:
-    c_test_dir      : C test file directory
-    iss_yaml        : ISS configuration file in YAML format
-    isa             : ISA variant passed to the ISS
-    mabi            : MABI variant passed to GCC
-    gcc_opts        : User-defined options for GCC compilation
-    iss             : Instruction set simulators
-    output_dir      : Output directory of compiled test files
-    setting_dir     : Generator setting directory
-    debug_cmd       : Produce the debug cmd log without running
-  """
-  result = run_cmd("find %s -name \"*.c\"" % c_test_dir)
-  if result:
-    c_list = result.splitlines()
-    logging.info("Found %0d c tests under %s" %
-                 (len(c_list), c_test_dir))
-    for c_file in c_list:
-      run_c(c_file, iss_yaml, isa, mabi, gcc_opts, iss, output_dir,
-            setting_dir, debug_cmd)
-      if "," in iss:
-        report = ("%s/iss_regr.log" % output_dir).rstrip()
-        save_regr_report(report)
-  else:
-    logging.error("No c test(*.c) found under %s" % c_test_dir)
+    Args:
+      c_test_dir      : C test file directory
+      iss_yaml        : ISS configuration file in YAML format
+      isa             : ISA variant passed to the ISS
+      mabi            : MABI variant passed to GCC
+      gcc_opts        : User-defined options for GCC compilation
+      iss             : Instruction set simulators
+      output_dir      : Output directory of compiled test files
+      setting_dir     : Generator setting directory
+      debug_cmd       : Produce the debug cmd log without running
+    """
+    result = run_cmd("find {} -name \"*.c\"".format(c_test_dir))
+    if result:
+        c_list = result.splitlines()
+        logging.info("Found {} c tests under {}".format(len(c_list), c_test_dir))
+        for c_file in c_list:
+            run_c(c_file, iss_yaml, isa, mabi, gcc_opts, iss, output_dir,
+                  setting_dir, debug_cmd)
+            if "," in iss:
+                report = ("{}/iss_regr.log".format(output_dir)).rstrip()
+                save_regr_report(report)
+    else:
+        logging.error("No c test(*.c) found under {}".format(c_test_dir))
 
 
 def iss_sim(test_list, output_dir, iss_list, iss_yaml, iss_opts,
             isa, setting_dir, timeout_s, debug_cmd):
-  """Run ISS simulation with the generated test program
+    """Run ISS simulation with the generated test program
 
-  Args:
-    test_list   : List of assembly programs to be compiled
-    output_dir  : Output directory of the ELF files
-    iss_list    : List of instruction set simulators
-    iss_yaml    : ISS configuration file in YAML format
-    iss_opts    : ISS command line options
-    isa         : ISA variant passed to the ISS
-    setting_dir : Generator setting directory
-    timeout_s   : Timeout limit in seconds
-    debug_cmd   : Produce the debug cmd log without running
-  """
-  for iss in iss_list.split(","):
-    log_dir = ("%s/%s_sim" % (output_dir, iss))
-    base_cmd = parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd)
-    logging.info("%s sim log dir: %s" % (iss, log_dir))
-    run_cmd_output(["mkdir", "-p", log_dir])
-    for test in test_list:
-      if 'no_iss' in test and test['no_iss'] == 1:
-        continue
-      else:
-        for i in range(0, test['iterations']):
-          prefix = ("%s/asm_tests/%s_%d" % (output_dir, test['test'], i))
-          elf = prefix + ".o"
-          log = ("%s/%s.%d.log" % (log_dir, test['test'], i))
-          cmd = get_iss_cmd(base_cmd, elf, log)
-          if 'iss_opts' in test:
-            cmd += ' '
-            cmd += test['iss_opts']
-          logging.info("Running %s sim: %s" % (iss, elf))
-          if iss == "ovpsim":
-            run_cmd(cmd, timeout_s, debug_cmd = debug_cmd)
-          else:
-            run_cmd(cmd, timeout_s, debug_cmd = debug_cmd)
-          logging.debug(cmd)
+    Args:
+      test_list   : List of assembly programs to be compiled
+      output_dir  : Output directory of the ELF files
+      iss_list    : List of instruction set simulators
+      iss_yaml    : ISS configuration file in YAML format
+      iss_opts    : ISS command line options
+      isa         : ISA variant passed to the ISS
+      setting_dir : Generator setting directory
+      timeout_s   : Timeout limit in seconds
+      debug_cmd   : Produce the debug cmd log without running
+    """
+    for iss in iss_list.split(","):
+        log_dir = ("{}/{}_sim".format(output_dir, iss))
+        base_cmd = parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd)
+        logging.info("{} sim log dir: {}".format(iss, log_dir))
+        run_cmd_output(["mkdir", "-p", log_dir])
+        for test in test_list:
+            if 'no_iss' in test and test['no_iss'] == 1:
+                continue
+            else:
+                for i in range(0, test['iterations']):
+                    prefix = ("{}/asm_tests/{}_{}".format(
+                        output_dir, test['test'], i))
+                    elf = prefix + ".o"
+                    log = ("{}/{}.{}.log".format(log_dir, test['test'], i))
+                    cmd = get_iss_cmd(base_cmd, elf, log)
+                    if 'iss_opts' in test:
+                        cmd += ' '
+                        cmd += test['iss_opts']
+                    logging.info("Running {} sim: {}".format(iss, elf))
+                    if iss == "ovpsim":
+                        run_cmd(cmd, timeout_s, debug_cmd=debug_cmd)
+                    else:
+                        run_cmd(cmd, timeout_s, debug_cmd=debug_cmd)
+                    logging.debug(cmd)
 
 
 def iss_cmp(test_list, iss, output_dir, stop_on_first_error, exp, debug_cmd):
-  """Compare ISS simulation reult
+    """Compare ISS simulation reult
 
-  Args:
-    test_list      : List of assembly programs to be compiled
-    iss            : List of instruction set simulators
-    output_dir     : Output directory of the ELF files
-    stop_on_first_error : will end run on first error detected
-    exp            : Use experimental version
-    debug_cmd      : Produce the debug cmd log without running
-  """
-  if debug_cmd:
-    return
-  iss_list = iss.split(",")
-  if len(iss_list) != 2:
-    return
-  report = ("%s/iss_regr.log" % output_dir).rstrip()
-  run_cmd("rm -rf %s" % report)
-  for test in test_list:
-    for i in range(0, test['iterations']):
-      elf = ("%s/asm_tests/%s_%d.o" % (output_dir, test['test'], i))
-      logging.info("Comparing ISS sim result %s/%s : %s" %
-                  (iss_list[0], iss_list[1], elf))
-      log_list = []
-      run_cmd(("echo 'Test binary: %s' >> %s" % (elf, report)))
-      for iss in iss_list:
-        log_list.append("%s/%s_sim/%s.%d.log" % (output_dir, iss, test['test'], i))
-      compare_iss_log(iss_list, log_list, report, stop_on_first_error, exp)
-  save_regr_report(report)
+    Args:
+      test_list      : List of assembly programs to be compiled
+      iss            : List of instruction set simulators
+      output_dir     : Output directory of the ELF files
+      stop_on_first_error : will end run on first error detected
+      exp            : Use experimental version
+      debug_cmd      : Produce the debug cmd log without running
+    """
+    if debug_cmd:
+        return
+    iss_list = iss.split(",")
+    if len(iss_list) != 2:
+        return
+    report = ("{}/iss_regr.log".format(output_dir)).rstrip()
+    run_cmd("rm -rf {}".format(report))
+    for test in test_list:
+        for i in range(0, test['iterations']):
+            elf = ("{}/asm_tests/{}_{}.o".format(output_dir, test['test'], i))
+            logging.info("Comparing ISS sim result {}/{} : {}".format(
+                iss_list[0], iss_list[1], elf))
+            log_list = []
+            run_cmd(("echo 'Test binary: {}' >> {}".format(elf, report)))
+            for iss in iss_list:
+                log_list.append(
+                    "{}/{}_sim/{}.{}.log".format(output_dir, iss, test['test'], i))
+            compare_iss_log(iss_list, log_list, report, stop_on_first_error,
+                            exp)
+    save_regr_report(report)
 
 
-def compare_iss_log(iss_list, log_list, report, stop_on_first_error=0, exp=False):
-  if (len(iss_list) != 2 or len(log_list) != 2) :
-    logging.error("Only support comparing two ISS logs")
-  else:
-    csv_list = []
-    for i in range(2):
-      log = log_list[i]
-      csv = log.replace(".log", ".csv");
-      iss = iss_list[i]
-      csv_list.append(csv)
-      if iss == "spike":
-        process_spike_sim_log(log, csv)
-      elif iss == "ovpsim":
-        process_ovpsim_sim_log(log, csv, stop_on_first_error)
-      elif iss == "sail":
-        process_sail_sim_log(log, csv)
-      elif iss == "whisper":
-        process_whisper_sim_log(log, csv)
-      else:
-        logging.error("Unsupported ISS" % iss)
-        sys.exit(RET_FAIL)
-    result = compare_trace_csv(csv_list[0], csv_list[1], iss_list[0], iss_list[1], report)
-    logging.info(result)
+def compare_iss_log(iss_list, log_list, report, stop_on_first_error=0,
+                    exp=False):
+    if len(iss_list) != 2 or len(log_list) != 2:
+        logging.error("Only support comparing two ISS logs")
+    else:
+        csv_list = []
+        for i in range(2):
+            log = log_list[i]
+            csv = log.replace(".log", ".csv")
+            iss = iss_list[i]
+            csv_list.append(csv)
+            if iss == "spike":
+                process_spike_sim_log(log, csv)
+            elif iss == "ovpsim":
+                process_ovpsim_sim_log(log, csv, stop_on_first_error)
+            elif iss == "sail":
+                process_sail_sim_log(log, csv)
+            elif iss == "whisper":
+                process_whisper_sim_log(log, csv)
+            else:
+                logging.error("Unsupported ISS {}".format(iss))
+                sys.exit(RET_FAIL)
+        result = compare_trace_csv(csv_list[0], csv_list[1], iss_list[0],
+                                   iss_list[1], report)
+        logging.info(result)
 
 
 def save_regr_report(report):
-  passed_cnt = run_cmd("grep PASSED %s | wc -l" % report).strip()
-  failed_cnt = run_cmd("grep FAILED %s | wc -l" % report).strip()
-  summary = ("%s PASSED, %s FAILED" % (passed_cnt, failed_cnt))
-  logging.info(summary)
-  run_cmd(("echo %s >> %s" % (summary, report)))
-  logging.info("ISS regression report is saved to %s" % report)
+    passed_cnt = run_cmd("grep PASSED {} | wc -l".format(report)).strip()
+    failed_cnt = run_cmd("grep FAILED {} | wc -l".format(report)).strip()
+    summary = ("{} PASSED, {} FAILED".format(passed_cnt, failed_cnt))
+    logging.info(summary)
+    run_cmd(("echo {} >> {}".format(summary, report)))
+    logging.info("ISS regression report is saved to {}".format(report))
 
 
 def read_seed(arg):
-    '''Read --seed or --seed_start'''
+    """Read --seed or --seed_start"""
     try:
         seed = int(arg)
         if seed < 0:
@@ -704,362 +744,397 @@ def read_seed(arg):
                                          'must be a non-negative integer.'
                                          .format(arg))
 
+
 def parse_args(cwd):
-  """Create a command line parser.
+    """Create a command line parser.
 
-  Returns: The created parser.
-  """
-  # Parse input arguments
-  parser = argparse.ArgumentParser()
+    Returns: The created parser.
+    """
+    # Parse input arguments
+    parser = argparse.ArgumentParser()
 
-  parser.add_argument("--target", type=str, default="rv32imc",
-                      help="Run the generator with pre-defined targets: \
+    parser.add_argument("--target", type=str, default="rv32imc",
+                        help="Run the generator with pre-defined targets: \
                             rv32imc, rv32i, rv64imc, rv64gc")
-  parser.add_argument("-o", "--output", type=str,
-                      help="Output directory name", dest="o")
-  parser.add_argument("-tl", "--testlist", type=str, default="",
-                      help="Regression testlist", dest="testlist")
-  parser.add_argument("-tn", "--test", type=str, default="all",
-                      help="Test name, 'all' means all tests in the list", dest="test")
-  parser.add_argument("-i", "--iterations", type=int, default=0,
-                      help="Override the iteration count in the test list", dest="iterations")
-  parser.add_argument("-si", "--simulator", type=str, default="vcs",
-                      help="Simulator used to run the generator, default VCS", dest="simulator")
-  parser.add_argument("--iss", type=str, default="spike",
-                      help="RISC-V instruction set simulator: spike,ovpsim,sail")
-  parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", default=False,
-                      help="Verbose logging")
-  parser.add_argument("--co", dest="co", action="store_true", default=False,
-                      help="Compile the generator only")
-  parser.add_argument("--cov", dest="cov", action="store_true", default=False,
-                      help="Enable functional coverage")
-  parser.add_argument("--so", dest="so", action="store_true", default=False,
-                      help="Simulate the generator only")
-  parser.add_argument("--cmp_opts", type=str, default="",
-                      help="Compile options for the generator")
-  parser.add_argument("--sim_opts", type=str, default="",
-                      help="Simulation options for the generator")
-  parser.add_argument("--gcc_opts", type=str, default="",
-                      help="GCC compile options")
-  parser.add_argument("-s", "--steps", type=str, default="all",
-                      help="Run steps: gen,gcc_compile,iss_sim,iss_cmp", dest="steps")
-  parser.add_argument("--lsf_cmd", type=str, default="",
-                      help="LSF command. Run in local sequentially if lsf \
+    parser.add_argument("-o", "--output", type=str,
+                        help="Output directory name", dest="o")
+    parser.add_argument("-tl", "--testlist", type=str, default="",
+                        help="Regression testlist", dest="testlist")
+    parser.add_argument("-tn", "--test", type=str, default="all",
+                        help="Test name, 'all' means all tests in the list",
+                        dest="test")
+    parser.add_argument("-i", "--iterations", type=int, default=0,
+                        help="Override the iteration count in the test list",
+                        dest="iterations")
+    parser.add_argument("-si", "--simulator", type=str, default="vcs",
+                        help="Simulator used to run the generator, default VCS",
+                        dest="simulator")
+    parser.add_argument("--iss", type=str, default="spike",
+                        help="RISC-V instruction set simulator: spike,ovpsim,sail")
+    parser.add_argument("-v", "--verbose", dest="verbose", action="store_true",
+                        default=False,
+                        help="Verbose logging")
+    parser.add_argument("--co", dest="co", action="store_true", default=False,
+                        help="Compile the generator only")
+    parser.add_argument("--cov", dest="cov", action="store_true", default=False,
+                        help="Enable functional coverage")
+    parser.add_argument("--so", dest="so", action="store_true", default=False,
+                        help="Simulate the generator only")
+    parser.add_argument("--cmp_opts", type=str, default="",
+                        help="Compile options for the generator")
+    parser.add_argument("--sim_opts", type=str, default="",
+                        help="Simulation options for the generator")
+    parser.add_argument("--gcc_opts", type=str, default="",
+                        help="GCC compile options")
+    parser.add_argument("-s", "--steps", type=str, default="all",
+                        help="Run steps: gen,gcc_compile,iss_sim,iss_cmp",
+                        dest="steps")
+    parser.add_argument("--lsf_cmd", type=str, default="",
+                        help="LSF command. Run in local sequentially if lsf \
                             command is not specified")
-  parser.add_argument("--isa", type=str, default="",
-                      help="RISC-V ISA subset")
-  parser.add_argument("-m", "--mabi", type=str, default="",
-                      help="mabi used for compilation", dest="mabi")
-  parser.add_argument("--gen_timeout", type=int, default=360,
-                      help="Generator timeout limit in seconds")
-  parser.add_argument("--end_signature_addr", type=str, default="0",
-                      help="Address that privileged CSR test writes to at EOT")
-  parser.add_argument("--iss_opts", type=str, default="",
-                      help="Any ISS command line arguments")
-  parser.add_argument("--iss_timeout", type=int, default=10,
-                      help="ISS sim timeout limit in seconds")
-  parser.add_argument("--iss_yaml", type=str, default="",
-                      help="ISS setting YAML")
-  parser.add_argument("--simulator_yaml", type=str, default="",
-                      help="RTL/pyflow simulator setting YAML")
-  parser.add_argument("--csr_yaml", type=str, default="",
-                      help="CSR description file")
-  parser.add_argument("-ct", "--custom_target", type=str, default="",
-                      help="Directory name of the custom target")
-  parser.add_argument("-cs", "--core_setting_dir", type=str, default="",
-                      help="Path for the riscv_core_setting.sv")
-  parser.add_argument("-ext", "--user_extension_dir", type=str, default="",
-                      help="Path for the user extension directory")
-  parser.add_argument("--asm_tests", type=str, default="",
-                      help="Directed assembly tests")
-  parser.add_argument("--c_tests", type=str, default="",
-                      help="Directed c tests")
-  parser.add_argument("--log_suffix", type=str, default="",
-                      help="Simulation log name suffix")
-  parser.add_argument("--exp", action="store_true", default=False,
-                      help="Run generator with experimental features")
-  parser.add_argument("-bz", "--batch_size", type=int, default=0,
-                      help="Number of tests to generate per run. You can split a big"
-                           " job to small batches with this option")
-  parser.add_argument("--stop_on_first_error", dest="stop_on_first_error",
-                      action="store_true", default=False,
-                      help="Stop on detecting first error")
-  parser.add_argument("--noclean", action="store_true", default=True,
-                      help="Do not clean the output of the previous runs")
-  parser.add_argument("--verilog_style_check", action="store_true", default=False,
-                      help="Run verilog style check")
-  parser.add_argument("-d", "--debug", type=str, default="",
-                      help="Generate debug command log file")
+    parser.add_argument("--isa", type=str, default="",
+                        help="RISC-V ISA subset")
+    parser.add_argument("-m", "--mabi", type=str, default="",
+                        help="mabi used for compilation", dest="mabi")
+    parser.add_argument("--gen_timeout", type=int, default=360,
+                        help="Generator timeout limit in seconds")
+    parser.add_argument("--end_signature_addr", type=str, default="0",
+                        help="Address that privileged CSR test writes to at EOT")
+    parser.add_argument("--iss_opts", type=str, default="",
+                        help="Any ISS command line arguments")
+    parser.add_argument("--iss_timeout", type=int, default=10,
+                        help="ISS sim timeout limit in seconds")
+    parser.add_argument("--iss_yaml", type=str, default="",
+                        help="ISS setting YAML")
+    parser.add_argument("--simulator_yaml", type=str, default="",
+                        help="RTL/pyflow simulator setting YAML")
+    parser.add_argument("--csr_yaml", type=str, default="",
+                        help="CSR description file")
+    parser.add_argument("-ct", "--custom_target", type=str, default="",
+                        help="Directory name of the custom target")
+    parser.add_argument("-cs", "--core_setting_dir", type=str, default="",
+                        help="Path for the riscv_core_setting.sv")
+    parser.add_argument("-ext", "--user_extension_dir", type=str, default="",
+                        help="Path for the user extension directory")
+    parser.add_argument("--asm_tests", type=str, default="",
+                        help="Directed assembly tests")
+    parser.add_argument("--c_tests", type=str, default="",
+                        help="Directed c tests")
+    parser.add_argument("--log_suffix", type=str, default="",
+                        help="Simulation log name suffix")
+    parser.add_argument("--exp", action="store_true", default=False,
+                        help="Run generator with experimental features")
+    parser.add_argument("-bz", "--batch_size", type=int, default=0,
+                        help="Number of tests to generate per run. You can split a big"
+                             " job to small batches with this option")
+    parser.add_argument("--stop_on_first_error", dest="stop_on_first_error",
+                        action="store_true", default=False,
+                        help="Stop on detecting first error")
+    parser.add_argument("--noclean", action="store_true", default=True,
+                        help="Do not clean the output of the previous runs")
+    parser.add_argument("--verilog_style_check", action="store_true",
+                        default=False,
+                        help="Run verilog style check")
+    parser.add_argument("-d", "--debug", type=str, default="",
+                        help="Generate debug command log file")
 
-  rsg = parser.add_argument_group('Random seeds',
-                                  'To control random seeds, use at most one '
-                                  'of the --start_seed, --seed or --seed_yaml '
-                                  'arguments. Since the latter two only give '
-                                  'a single seed for each test, they imply '
-                                  '--iterations=1.')
+    rsg = parser.add_argument_group('Random seeds',
+                                    'To control random seeds, use at most one '
+                                    'of the --start_seed, --seed or --seed_yaml '
+                                    'arguments. Since the latter two only give '
+                                    'a single seed for each test, they imply '
+                                    '--iterations=1.')
 
-  rsg.add_argument("--start_seed", type=read_seed,
-                   help=("Randomization seed to use for first iteration of "
-                         "each test. Subsequent iterations use seeds "
-                         "counting up from there. Cannot be used with "
-                         "--seed or --seed_yaml."))
-  rsg.add_argument("--seed", type=read_seed,
-                   help=("Randomization seed to use for each test. "
-                         "Implies --iterations=1. Cannot be used with "
-                         "--start_seed or --seed_yaml."))
-  rsg.add_argument("--seed_yaml", type=str,
-                   help=("Rerun the generator with the seed specification "
-                         "from a prior regression. Implies --iterations=1. "
-                         "Cannot be used with --start_seed or --seed."))
+    rsg.add_argument("--start_seed", type=read_seed,
+                     help=("Randomization seed to use for first iteration of "
+                           "each test. Subsequent iterations use seeds "
+                           "counting up from there. Cannot be used with "
+                           "--seed or --seed_yaml."))
+    rsg.add_argument("--seed", type=read_seed,
+                     help=("Randomization seed to use for each test. "
+                           "Implies --iterations=1. Cannot be used with "
+                           "--start_seed or --seed_yaml."))
+    rsg.add_argument("--seed_yaml", type=str,
+                     help=("Rerun the generator with the seed specification "
+                           "from a prior regression. Implies --iterations=1. "
+                           "Cannot be used with --start_seed or --seed."))
 
-  args = parser.parse_args()
+    args = parser.parse_args()
 
-  if args.seed is not None and args.start_seed is not None:
-    logging.error('--start_seed and --seed are mutually exclusive.')
-    sys.exit(RET_FAIL)
+    if args.seed is not None and args.start_seed is not None:
+        logging.error('--start_seed and --seed are mutually exclusive.')
+        sys.exit(RET_FAIL)
 
-  if args.seed is not None:
-    if args.iterations == 0:
-      args.iterations = 1
-    elif args.iterations > 1:
-      logging.error('--seed is incompatible with setting --iterations '
-                    'greater than 1.')
-      sys.exit(RET_FAIL)
+    if args.seed is not None:
+        if args.iterations == 0:
+            args.iterations = 1
+        elif args.iterations > 1:
+            logging.error('--seed is incompatible with setting --iterations '
+                          'greater than 1.')
+            sys.exit(RET_FAIL)
 
-  # We've parsed all the arguments from the command line; default values
-  # can be set in the config file. Read that here.
-  load_config(args, cwd)
+    # We've parsed all the arguments from the command line; default values
+    # can be set in the config file. Read that here.
+    load_config(args, cwd)
 
-  return args
+    return args
 
 
 def load_config(args, cwd):
-  """
+    """
   Load configuration from the command line and the configuration file.
   Args:
       args:   Parsed command-line configuration
   Returns:
       Loaded configuration dictionary.
   """
-  if args.debug:
-    args.debug = open(args.debug, "w")
-  if not args.csr_yaml:
-    args.csr_yaml = cwd + "/yaml/csr_template.yaml"
+    if args.debug:
+        args.debug = open(args.debug, "w")
+    if not args.csr_yaml:
+        args.csr_yaml = cwd + "/yaml/csr_template.yaml"
 
-  if not args.iss_yaml:
-    args.iss_yaml = cwd + "/yaml/iss.yaml"
+    if not args.iss_yaml:
+        args.iss_yaml = cwd + "/yaml/iss.yaml"
 
-  if not args.simulator_yaml:
-    args.simulator_yaml = cwd + "/yaml/simulator.yaml"
+    if not args.simulator_yaml:
+        args.simulator_yaml = cwd + "/yaml/simulator.yaml"
 
-  # Keep the core_setting_dir option to be backward compatible, suggest to use
-  # --custom_target
-  if args.core_setting_dir:
+    # Keep the core_setting_dir option to be backward compatible, suggest to use
+    # --custom_target
+    if args.core_setting_dir:
+        if not args.custom_target:
+            args.custom_target = args.core_setting_dir
+    else:
+        args.core_setting_dir = args.custom_target
+
     if not args.custom_target:
-      args.custom_target = args.core_setting_dir
-  else:
-    args.core_setting_dir = args.custom_target
-
-  if not args.custom_target:
-    if not args.testlist:
-      args.testlist = cwd + "/target/"+ args.target +"/testlist.yaml"
-    if args.simulator == "pyflow":
-      args.core_setting_dir = cwd + "/pygen/pygen_src/target/"+ args.target
+        if not args.testlist:
+            args.testlist = cwd + "/target/" + args.target + "/testlist.yaml"
+        if args.simulator == "pyflow":
+            args.core_setting_dir = cwd + "/pygen/pygen_src/target/" + args.target
+        else:
+            args.core_setting_dir = cwd + "/target/" + args.target
+        if args.target == "rv32imc":
+            args.mabi = "ilp32"
+            args.isa = "rv32imc"
+        elif args.target == "rv32imc_sv32":
+            args.mabi = "ilp32"
+            args.isa = "rv32imc"
+        elif args.target == "multi_harts":
+            args.mabi = "ilp32"
+            args.isa = "rv32gc"
+        elif args.target == "rv32imcb":
+            args.mabi = "ilp32"
+            args.isa = "rv32imcb"
+        elif args.target == "rv32i":
+            args.mabi = "ilp32"
+            args.isa = "rv32i"
+        elif args.target == "rv64imc":
+            args.mabi = "lp64"
+            args.isa = "rv64imc"
+        elif args.target == "rv64imcb":
+            args.mabi = "lp64"
+            args.isa = "rv64imcb"
+        elif args.target == "rv64gc":
+            args.mabi = "lp64"
+            args.isa = "rv64gc"
+        elif args.target == "rv64gcv":
+            args.mabi = "lp64"
+            args.isa = "rv64gcv"
+        elif args.target == "ml":
+            args.mabi = "lp64"
+            args.isa = "rv64imc"
+        else:
+            sys.exit("Unsupported pre-defined target: {}".format(args.target))
     else:
-      args.core_setting_dir = cwd + "/target/"+ args.target
-    if args.target == "rv32imc":
-      args.mabi = "ilp32"
-      args.isa  = "rv32imc"
-    elif args.target == "rv32imc_sv32":
-      args.mabi = "ilp32"
-      args.isa  = "rv32imc"
-    elif args.target == "multi_harts":
-      args.mabi = "ilp32"
-      args.isa  = "rv32gc"
-    elif args.target == "rv32imcb":
-      args.mabi = "ilp32"
-      args.isa  = "rv32imcb"
-    elif args.target == "rv32i":
-      args.mabi = "ilp32"
-      args.isa  = "rv32i"
-    elif args.target == "rv64imc":
-      args.mabi = "lp64"
-      args.isa  = "rv64imc"
-    elif args.target == "rv64imcb":
-      args.mabi = "lp64"
-      args.isa  = "rv64imcb"
-    elif args.target == "rv64gc":
-      args.mabi = "lp64"
-      args.isa  = "rv64gc"
-    elif args.target == "rv64gcv":
-      args.mabi = "lp64"
-      args.isa  = "rv64gcv"
-    elif args.target == "ml":
-      args.mabi = "lp64"
-      args.isa  = "rv64imc"
-    else:
-      sys.exit("Unsupported pre-defined target: %0s" % args.target)
-  else:
-    if re.match(".*gcc_compile.*", args.steps) or re.match(".*iss_sim.*", args.steps):
-      if (not args.mabi) or (not args.isa):
-        sys.exit("mabi and isa must be specified for custom target %0s" % args.custom_target)
-    if not args.testlist:
-      args.testlist = args.custom_target + "/testlist.yaml"
+        if re.match(".*gcc_compile.*", args.steps) or re.match(".*iss_sim.*",
+                                                               args.steps):
+            if (not args.mabi) or (not args.isa):
+                sys.exit(
+                    "mabi and isa must be specified for custom target {}".format(
+                        args.custom_target))
+        if not args.testlist:
+            args.testlist = args.custom_target + "/testlist.yaml"
 
 
 def main():
-  """This is the main entry point."""
-  try:
-    cwd = os.path.dirname(os.path.realpath(__file__))
-    os.environ["RISCV_DV_ROOT"] = cwd
+    """This is the main entry point."""
+    try:
+        cwd = os.path.dirname(os.path.realpath(__file__))
+        os.environ["RISCV_DV_ROOT"] = cwd
 
-    args = parse_args(cwd)
-    setup_logging(args.verbose)
+        args = parse_args(cwd)
+        setup_logging(args.verbose)
 
-    # Create output directory
-    output_dir = create_output(args.o, args.noclean)
+        # Create output directory
+        output_dir = create_output(args.o, args.noclean)
 
-    if args.verilog_style_check:
-      logging.debug("Run style check")
-      style_err = run_cmd("verilog_style/run.sh")
-      if style_err: logging.info("Found style error: \nERROR: " + style_err)
+        if args.verilog_style_check:
+            logging.debug("Run style check")
+            style_err = run_cmd("verilog_style/run.sh")
+            if style_err: logging.info(
+                "Found style error: \nERROR: " + style_err)
 
-    # Run any handcoded/directed assembly tests specified by args.asm_tests
-    if args.asm_tests != "":
-      asm_test = args.asm_tests.split(',')
-      for path_asm_test in asm_test:
-        full_path = os.path.expanduser(path_asm_test)
-        # path_asm_test is a directory
-        if os.path.isdir(full_path):
-          run_assembly_from_dir(full_path, args.iss_yaml, args.isa, args.mabi,
-                                args.gcc_opts, args.iss, output_dir,
-                                args.core_setting_dir, args.debug)
-        # path_asm_test is an assembly file
-        elif os.path.isfile(full_path) or args.debug:
-          run_assembly(full_path, args.iss_yaml, args.isa, args.mabi, args.gcc_opts,
-                       args.iss, output_dir, args.core_setting_dir, args.debug)
-        else:
-          logging.error('%s does not exist' % full_path)
-          sys.exit(RET_FAIL)
-      return
+        # Run any handcoded/directed assembly tests specified by args.asm_tests
+        if args.asm_tests != "":
+            asm_test = args.asm_tests.split(',')
+            for path_asm_test in asm_test:
+                full_path = os.path.expanduser(path_asm_test)
+                # path_asm_test is a directory
+                if os.path.isdir(full_path):
+                    run_assembly_from_dir(full_path, args.iss_yaml, args.isa,
+                                          args.mabi,
+                                          args.gcc_opts, args.iss, output_dir,
+                                          args.core_setting_dir, args.debug)
+                # path_asm_test is an assembly file
+                elif os.path.isfile(full_path) or args.debug:
+                    run_assembly(full_path, args.iss_yaml, args.isa, args.mabi,
+                                 args.gcc_opts,
+                                 args.iss, output_dir, args.core_setting_dir,
+                                 args.debug)
+                else:
+                    logging.error('{} does not exist'.format(full_path))
+                    sys.exit(RET_FAIL)
+            return
 
-    # Run any handcoded/directed c tests specified by args.c_tests
-    if args.c_tests != "":
-      c_test = args.c_tests.split(',')
-      for path_c_test in c_test:
-        full_path = os.path.expanduser(path_c_test)
-        # path_c_test is a directory
-        if os.path.isdir(full_path):
-          run_c_from_dir(full_path, args.iss_yaml, args.isa, args.mabi,
-                         args.gcc_opts, args.iss, output_dir,
-                         args.core_setting_dir, args.debug)
-        # path_c_test is a c file
-        elif os.path.isfile(full_path) or args.debug:
-          run_c(full_path, args.iss_yaml, args.isa, args.mabi, args.gcc_opts,
-                args.iss, output_dir, args.core_setting_dir, args.debug)
-        else:
-          logging.error('%s does not exist' % full_path)
-          sys.exit(RET_FAIL)
-      return
+        # Run any handcoded/directed c tests specified by args.c_tests
+        if args.c_tests != "":
+            c_test = args.c_tests.split(',')
+            for path_c_test in c_test:
+                full_path = os.path.expanduser(path_c_test)
+                # path_c_test is a directory
+                if os.path.isdir(full_path):
+                    run_c_from_dir(full_path, args.iss_yaml, args.isa,
+                                   args.mabi,
+                                   args.gcc_opts, args.iss, output_dir,
+                                   args.core_setting_dir, args.debug)
+                # path_c_test is a c file
+                elif os.path.isfile(full_path) or args.debug:
+                    run_c(full_path, args.iss_yaml, args.isa, args.mabi,
+                          args.gcc_opts,
+                          args.iss, output_dir, args.core_setting_dir,
+                          args.debug)
+                else:
+                    logging.error('{} does not exist'.format(full_path))
+                    sys.exit(RET_FAIL)
+            return
 
-    run_cmd_output(["mkdir", "-p", ("%s/asm_tests" % output_dir)])
-    # Process regression test list
-    matched_list = []
-    # Any tests in the YAML test list that specify a directed assembly test
-    asm_directed_list = []
-    # Any tests in the YAML test list that specify a directed c test
-    c_directed_list = []
+        run_cmd_output(["mkdir", "-p", ("{}/asm_tests".format(output_dir))])
+        # Process regression test list
+        matched_list = []
+        # Any tests in the YAML test list that specify a directed assembly test
+        asm_directed_list = []
+        # Any tests in the YAML test list that specify a directed c test
+        c_directed_list = []
 
-    if not args.co:
-      process_regression_list(args.testlist, args.test, args.iterations, matched_list, cwd)
-      for t in list(matched_list):
-        # Check mutual exclusive between gen_test, asm_tests, and c_tests
-        if 'asm_tests' in t:
-          if 'gen_test' in t or 'c_tests' in t:
-            logging.error('asm_tests must not be defined in the testlist '
-                          'together with the gen_test or c_tests field')
-            sys.exit(RET_FATAL)
-          asm_directed_list.append(t)
-          matched_list.remove(t)
+        if not args.co:
+            process_regression_list(args.testlist, args.test, args.iterations,
+                                    matched_list, cwd)
+            for t in list(matched_list):
+                # Check mutual exclusive between gen_test, asm_tests, and c_tests
+                if 'asm_tests' in t:
+                    if 'gen_test' in t or 'c_tests' in t:
+                        logging.error(
+                            'asm_tests must not be defined in the testlist '
+                            'together with the gen_test or c_tests field')
+                        sys.exit(RET_FATAL)
+                    asm_directed_list.append(t)
+                    matched_list.remove(t)
 
-        if 'c_tests' in t:
-          if 'gen_test' in t or 'asm_tests' in t:
-            logging.error('c_tests must not be defined in the testlist '
-                          'together with the gen_test or asm_tests field')
-            sys.exit(RET_FATAL)
-          c_directed_list.append(t)
-          matched_list.remove(t)
+                if 'c_tests' in t:
+                    if 'gen_test' in t or 'asm_tests' in t:
+                        logging.error(
+                            'c_tests must not be defined in the testlist '
+                            'together with the gen_test or asm_tests field')
+                        sys.exit(RET_FATAL)
+                    c_directed_list.append(t)
+                    matched_list.remove(t)
 
-      if len(matched_list) == 0 and len(asm_directed_list) == 0 and len(c_directed_list) == 0:
-        sys.exit("Cannot find %s in %s" % (args.test, args.testlist))
+            if len(matched_list) == 0 and len(asm_directed_list) == 0 and len(
+                    c_directed_list) == 0:
+                sys.exit("Cannot find {} in {}".format(args.test, args.testlist))
 
-    # Run instruction generator
-    if args.steps == "all" or re.match(".*gen.*", args.steps):
-      # Run any handcoded/directed assembly tests specified in YAML format
-      if len(asm_directed_list) != 0:
-        for test_entry in asm_directed_list:
-          gcc_opts = args.gcc_opts
-          gcc_opts += test_entry.get('gcc_opts', '')
-          path_asm_test = os.path.expanduser(test_entry.get('asm_tests'))
-          if path_asm_test:
-            # path_asm_test is a directory
-            if os.path.isdir(path_asm_test):
-              run_assembly_from_dir(path_asm_test, args.iss_yaml, args.isa, args.mabi,
-                                    gcc_opts, args.iss, output_dir,
-                                    args.core_setting_dir, args.debug)
-            # path_asm_test is an assembly file
-            elif os.path.isfile(path_asm_test):
-              run_assembly(path_asm_test, args.iss_yaml, args.isa, args.mabi, gcc_opts,
-                           args.iss, output_dir, args.core_setting_dir, args.debug)
-            else:
-              if not args.debug:
-                logging.error('%s does not exist' % path_asm_test)
-                sys.exit(RET_FAIL)
+        # Run instruction generator
+        if args.steps == "all" or re.match(".*gen.*", args.steps):
+            # Run any handcoded/directed assembly tests specified in YAML format
+            if len(asm_directed_list) != 0:
+                for test_entry in asm_directed_list:
+                    gcc_opts = args.gcc_opts
+                    gcc_opts += test_entry.get('gcc_opts', '')
+                    path_asm_test = os.path.expanduser(
+                        test_entry.get('asm_tests'))
+                    if path_asm_test:
+                        # path_asm_test is a directory
+                        if os.path.isdir(path_asm_test):
+                            run_assembly_from_dir(path_asm_test, args.iss_yaml,
+                                                  args.isa, args.mabi,
+                                                  gcc_opts, args.iss,
+                                                  output_dir,
+                                                  args.core_setting_dir,
+                                                  args.debug)
+                        # path_asm_test is an assembly file
+                        elif os.path.isfile(path_asm_test):
+                            run_assembly(path_asm_test, args.iss_yaml, args.isa,
+                                         args.mabi, gcc_opts,
+                                         args.iss, output_dir,
+                                         args.core_setting_dir, args.debug)
+                        else:
+                            if not args.debug:
+                                logging.error(
+                                    '{} does not exist'.format(path_asm_test))
+                                sys.exit(RET_FAIL)
 
-      # Run any handcoded/directed C tests specified in YAML format
-      if len(c_directed_list) != 0:
-        for test_entry in c_directed_list:
-          gcc_opts = args.gcc_opts
-          gcc_opts += test_entry.get('gcc_opts', '')
-          path_c_test = os.path.expanduser(test_entry.get('c_tests'))
-          if path_c_test:
-            # path_c_test is a directory
-            if os.path.isdir(path_c_test):
-              run_c_from_dir(path_c_test, args.iss_yaml, args.isa, args.mabi,
-                             gcc_opts, args.iss, output_dir,
-                             args.core_setting_dir, args.debug)
-            # path_c_test is a C file
-            elif os.path.isfile(path_c_test):
-              run_c(path_c_test, args.iss_yaml, args.isa, args.mabi, gcc_opts,
-                    args.iss, output_dir, args.core_setting_dir, args.debug)
-            else:
-              if not args.debug:
-                logging.error('%s does not exist' % path_c_test)
-                sys.exit(RET_FAIL)
+            # Run any handcoded/directed C tests specified in YAML format
+            if len(c_directed_list) != 0:
+                for test_entry in c_directed_list:
+                    gcc_opts = args.gcc_opts
+                    gcc_opts += test_entry.get('gcc_opts', '')
+                    path_c_test = os.path.expanduser(test_entry.get('c_tests'))
+                    if path_c_test:
+                        # path_c_test is a directory
+                        if os.path.isdir(path_c_test):
+                            run_c_from_dir(path_c_test, args.iss_yaml, args.isa,
+                                           args.mabi,
+                                           gcc_opts, args.iss, output_dir,
+                                           args.core_setting_dir, args.debug)
+                        # path_c_test is a C file
+                        elif os.path.isfile(path_c_test):
+                            run_c(path_c_test, args.iss_yaml, args.isa,
+                                  args.mabi, gcc_opts,
+                                  args.iss, output_dir, args.core_setting_dir,
+                                  args.debug)
+                        else:
+                            if not args.debug:
+                                logging.error('{} does not exist'.format(path_c_test))
+                                sys.exit(RET_FAIL)
 
-      # Run remaining tests using the instruction generator
-      gen(matched_list, args, output_dir, cwd)
+            # Run remaining tests using the instruction generator
+            gen(matched_list, args, output_dir, cwd)
 
-    if not args.co:
-      # Compile the assembly program to ELF, convert to plain binary
-      if args.steps == "all" or re.match(".*gcc_compile.*", args.steps):
-        gcc_compile(matched_list, output_dir, args.isa, args.mabi,
-                    args.gcc_opts, args.debug)
+        if not args.co:
+            # Compile the assembly program to ELF, convert to plain binary
+            if args.steps == "all" or re.match(".*gcc_compile.*", args.steps):
+                gcc_compile(matched_list, output_dir, args.isa, args.mabi,
+                            args.gcc_opts, args.debug)
 
-      # Run ISS simulation
-      if args.steps == "all" or re.match(".*iss_sim.*", args.steps):
-        iss_sim(matched_list, output_dir, args.iss, args.iss_yaml, args.iss_opts,
-                args.isa, args.core_setting_dir, args.iss_timeout, args.debug)
+            # Run ISS simulation
+            if args.steps == "all" or re.match(".*iss_sim.*", args.steps):
+                iss_sim(matched_list, output_dir, args.iss, args.iss_yaml,
+                        args.iss_opts,
+                        args.isa, args.core_setting_dir, args.iss_timeout,
+                        args.debug)
 
-      # Compare ISS simulation result
-      if args.steps == "all" or re.match(".*iss_cmp.*", args.steps):
-        iss_cmp(matched_list, args.iss, output_dir, args.stop_on_first_error,
-                args.exp, args.debug)
+            # Compare ISS simulation result
+            if args.steps == "all" or re.match(".*iss_cmp.*", args.steps):
+                iss_cmp(matched_list, args.iss, output_dir,
+                        args.stop_on_first_error,
+                        args.exp, args.debug)
 
-    sys.exit(RET_SUCCESS)
-  except KeyboardInterrupt:
-    logging.info("\nExited Ctrl-C from user request.")
-    sys.exit(130)
+        sys.exit(RET_SUCCESS)
+    except KeyboardInterrupt:
+        logging.info("\nExited Ctrl-C from user request.")
+        sys.exit(130)
+
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/scripts/gen_csr_test.py
+++ b/scripts/gen_csr_test.py
@@ -21,7 +21,6 @@ in the CSR at this point, allowing for the test to self-check in order to
 determine success or failure.
 """
 
-
 """
 To install the bitstring library:
   1) sudo apt-get install python3-bitstring OR
@@ -35,325 +34,361 @@ import copy
 from lib import *
 
 try:
-  from bitstring import BitArray as bitarray
+    from bitstring import BitArray as bitarray
 except ImportError as e:
-  logging.error("Please install bitstring package: sudo apt-get install python3-bitstring")
-  sys.exit(RET_FAIL)
+    logging.error(
+        "Please install bitstring package: sudo apt-get install python3-bitstring")
+    sys.exit(RET_FAIL)
 
 """
 Defines the test's success/failure values, one of which will be written to
 the chosen signature address to indicate the test's result.
 """
 TEST_RESULT = 1
-TEST_PASS   = 0
-TEST_FAIL   = 1
+TEST_PASS = 0
+TEST_FAIL = 1
+
 
 def get_csr_map(csr_file, xlen):
-  """
-  Parses the YAML file containing CSR descriptions.
+    """
+    Parses the YAML file containing CSR descriptions.
 
-  Args:
-    csr_file: The CSR YAML file.
-    xlen: The current RISC-V ISA bit length.
+    Args:
+      csr_file: The CSR YAML file.
+      xlen: The current RISC-V ISA bit length.
 
-  Returns:
-    A dictionary contining mappings for each CSR, of the form:
-    { csr_name : [csr_address, csr_val_bitarray, csr_write_mask_bitarray, csr_read_mask_bitarray] }
-  """
-  rv_string = "rv{}".format(str(xlen))
-  csrs = {}
-  with open(csr_file, "r") as c:
-    csr_description = yaml.safe_load(c)
-    for csr_dict in csr_description:
-      csr_name = csr_dict.get("csr")
-      csr_address = csr_dict.get("address")
-      assert(rv_string in csr_dict), "The {} CSR must be configured for rv{}".format(csr_name, str(rv))
-      csr_value = bitarray(uintbe=0, length=xlen)
-      csr_write_mask = []
-      csr_read_mask = bitarray(uintbe=0, length=xlen)
-      csr_field_list = csr_dict.get(rv_string)
-      for csr_field_detail_dict in csr_field_list:
-        field_type = csr_field_detail_dict.get("type")
-        field_val = csr_field_detail_dict.get("reset_val")
-        field_msb = csr_field_detail_dict.get("msb")
-        field_lsb = csr_field_detail_dict.get("lsb")
-        field_size = field_msb - field_lsb + 1
-        if field_type != "WPRI":
-          val_bitarray = bitarray(uint=field_val, length=field_size)
-          mask_bitarray = bitarray(uint=1, length=1) * field_size
-          start_pos = xlen - 1 - field_msb
-          end_pos = xlen - 1 - field_lsb
-          csr_read_mask.overwrite(mask_bitarray, xlen - 1 - field_msb)
-          csr_value.overwrite(val_bitarray, xlen - 1 - field_msb)
-          access = True if field_type == "R" else False
-          csr_write_mask.append([mask_bitarray, (start_pos, end_pos), access])
-      csrs.update({csr_name : [csr_address, csr_value, csr_write_mask, csr_read_mask]})
-  return csrs
+    Returns:
+      A dictionary contining mappings for each CSR, of the form:
+      { csr_name : [csr_address, csr_val_bitarray, csr_write_mask_bitarray, csr_read_mask_bitarray] }
+    """
+    rv_string = "rv{}".format(str(xlen))
+    csrs = {}
+    with open(csr_file, "r") as c:
+        csr_description = yaml.safe_load(c)
+        for csr_dict in csr_description:
+            csr_name = csr_dict.get("csr")
+            csr_address = csr_dict.get("address")
+            assert (rv_string in csr_dict), "The {} CSR must be configured for rv{}".format(
+                csr_name, str(rv))
+            csr_value = bitarray(uintbe=0, length=xlen)
+            csr_write_mask = []
+            csr_read_mask = bitarray(uintbe=0, length=xlen)
+            csr_field_list = csr_dict.get(rv_string)
+            for csr_field_detail_dict in csr_field_list:
+                field_type = csr_field_detail_dict.get("type")
+                field_val = csr_field_detail_dict.get("reset_val")
+                field_msb = csr_field_detail_dict.get("msb")
+                field_lsb = csr_field_detail_dict.get("lsb")
+                field_size = field_msb - field_lsb + 1
+                if field_type != "WPRI":
+                    val_bitarray = bitarray(uint=field_val, length=field_size)
+                    mask_bitarray = bitarray(uint=1, length=1) * field_size
+                    start_pos = xlen - 1 - field_msb
+                    end_pos = xlen - 1 - field_lsb
+                    csr_read_mask.overwrite(mask_bitarray, xlen - 1 - field_msb)
+                    csr_value.overwrite(val_bitarray, xlen - 1 - field_msb)
+                    access = True if field_type == "R" else False
+                    csr_write_mask.append(
+                        [mask_bitarray, (start_pos, end_pos), access])
+            csrs.update({csr_name: [csr_address, csr_value, csr_write_mask,
+                                    csr_read_mask]})
+    return csrs
 
 
 def get_rs1_val(iteration, xlen):
-  """
-  Calculates and returns the 3 test RS1 values that will be used
-  to exercise the CSR.
+    """
+    Calculates and returns the 3 test RS1 values that will be used
+    to exercise the CSR.
 
-  Args:
-    iteration: Integer between 0 and 2 inclusive, indicates which
-               test value to return.
-    xlen: The currnet RISC-V ISA bit length.
+    Args:
+      iteration: Integer between 0 and 2 inclusive, indicates which
+                 test value to return.
+      xlen: The currnet RISC-V ISA bit length.
 
-  Returns:
-    A bitarray encoding the value that will be written to the CSR to test it.
-    Will be one of 3 values:
-      1) 0xa5a5...
-      2) 0x5a5a...
-      3) A randomly generated number
-  """
-  if iteration == 0:
-    return bitarray(hex="0x{}".format('a5'*int(xlen/8)))
-  elif iteration == 1:
-    return bitarray(hex="0x{}".format('5a'*int(xlen/8)))
-  elif iteration == 2:
-    val = bitarray(uint=0, length=xlen)
-    # Must randomize all 32 bits, due to randomization library limitations
-    for i in range(32):
-      bit = random.randint(0, 1)
-      val.set(bit, i)
-    return val
+    Returns:
+      A bitarray encoding the value that will be written to the CSR to test it.
+      Will be one of 3 values:
+        1) 0xa5a5...
+        2) 0x5a5a...
+        3) A randomly generated number
+    """
+    if iteration == 0:
+        return bitarray(hex="0x{}".format('a5' * int(xlen / 8)))
+    elif iteration == 1:
+        return bitarray(hex="0x{}".format('5a' * int(xlen / 8)))
+    elif iteration == 2:
+        val = bitarray(uint=0, length=xlen)
+        # Must randomize all 32 bits, due to randomization library limitations
+        for i in range(32):
+            bit = random.randint(0, 1)
+            val.set(bit, i)
+        return val
 
 
 def csr_write(val, csr_val, csr_write_mask):
-  """
-  Performs a CSR write.
+    """
+    Performs a CSR write.
 
-  Args:
-    val: A bitarray containing the value to be written.
-    csr_val: A bitarray containing the current CSR value.
-    csr_write_mask: A bitarray containing the CSR's mask.
-  """
-  for bitslice in csr_write_mask:
-    read_only = bitslice[2]
-    start_index = bitslice[1][0]
-    end_index = bitslice[1][1]
-    length = end_index - start_index + 1
-    mask_val = bitslice[0]
-    # only write if not read only
-    if not read_only:
-      val_slice = val[start_index:end_index+1]
-      csr_val.overwrite(mask_val & val_slice, start_index)
+    Args:
+      val: A bitarray containing the value to be written.
+      csr_val: A bitarray containing the current CSR value.
+      csr_write_mask: A bitarray containing the CSR's mask.
+    """
+    for bitslice in csr_write_mask:
+        read_only = bitslice[2]
+        start_index = bitslice[1][0]
+        end_index = bitslice[1][1]
+        length = end_index - start_index + 1
+        mask_val = bitslice[0]
+        # only write if not read only
+        if not read_only:
+            val_slice = val[start_index:end_index + 1]
+            csr_val.overwrite(mask_val & val_slice, start_index)
 
 
 """
 CSR Read:
   Reads the given CSR, after applying the bitmask
 """
+
+
 def csr_read(csr_val, csr_read_mask):
-  """
-  Performs a CSR read.
+    """
+    Performs a CSR read.
 
-  Args:
-    csr_val: A bitarray containing the current CSR value.
-    csr_read_mask: A bitarray containing the CSR's read mask.
+    Args:
+      csr_val: A bitarray containing the current CSR value.
+      csr_read_mask: A bitarray containing the CSR's read mask.
 
-  Returns:
-    A bitarray of the logical AND of csr_val and csr_read_mask.
-  """
-  return csr_val & csr_read_mask
+    Returns:
+      A bitarray of the logical AND of csr_val and csr_read_mask.
+    """
+    return csr_val & csr_read_mask
 
 
 def predict_csr_val(csr_op, rs1_val, csr_val, csr_write_mask, csr_read_mask):
-  """
-  Predicts the CSR reference value, based on the current CSR operation.
+    """
+    Predicts the CSR reference value, based on the current CSR operation.
 
-  Args:
-    csr_op: A string of the CSR operation being performed.
-    rs1_val: A bitarray containing the value to be written to the CSR.
-    csr_val: A bitarray containing the current value of the CSR.
-    csr_write_mask: A bitarray containing the CSR's write mask.
-    csr_read_mask: A bitarray containing the CSR's read mask
+    Args:
+      csr_op: A string of the CSR operation being performed.
+      rs1_val: A bitarray containing the value to be written to the CSR.
+      csr_val: A bitarray containing the current value of the CSR.
+      csr_write_mask: A bitarray containing the CSR's write mask.
+      csr_read_mask: A bitarray containing the CSR's read mask
 
-  Returns:
-    A hexadecimal string of the predicted CSR value.
-  """
-  prediction = None
-  # create a zero bitarray to zero extend immediates
-  zero = bitarray(uint=0, length=csr_val.len - 5)
-  prediction = csr_read(csr_val, csr_read_mask)
-  if csr_op == 'csrrw':
-    csr_write(rs1_val, csr_val, csr_write_mask)
-  elif csr_op == 'csrrs':
-    csr_write(rs1_val | prediction, csr_val, csr_write_mask)
-  elif csr_op == 'csrrc':
-    csr_write((~rs1_val) & prediction, csr_val, csr_write_mask)
-  elif csr_op == 'csrrwi':
-    zero.append(rs1_val[-5:])
-    csr_write(zero, csr_val, csr_write_mask)
-  elif csr_op == 'csrrsi':
-    zero.append(rs1_val[-5:])
-    csr_write(zero | prediction, csr_val, csr_write_mask)
-  elif csr_op == 'csrrci':
-    zero.append(rs1_val[-5:])
-    csr_write((~zero) & prediction, csr_val, csr_write_mask)
-  return "0x{}".format(prediction.hex)
+    Returns:
+      A hexadecimal string of the predicted CSR value.
+    """
+    prediction = None
+    # create a zero bitarray to zero extend immediates
+    zero = bitarray(uint=0, length=csr_val.len - 5)
+    prediction = csr_read(csr_val, csr_read_mask)
+    if csr_op == 'csrrw':
+        csr_write(rs1_val, csr_val, csr_write_mask)
+    elif csr_op == 'csrrs':
+        csr_write(rs1_val | prediction, csr_val, csr_write_mask)
+    elif csr_op == 'csrrc':
+        csr_write((~rs1_val) & prediction, csr_val, csr_write_mask)
+    elif csr_op == 'csrrwi':
+        zero.append(rs1_val[-5:])
+        csr_write(zero, csr_val, csr_write_mask)
+    elif csr_op == 'csrrsi':
+        zero.append(rs1_val[-5:])
+        csr_write(zero | prediction, csr_val, csr_write_mask)
+    elif csr_op == 'csrrci':
+        zero.append(rs1_val[-5:])
+        csr_write((~zero) & prediction, csr_val, csr_write_mask)
+    return "0x{}".format(prediction.hex)
 
 
 def gen_setup(test_file):
-  """
-  Generates the setup code for the CSR test.
+    """
+    Generates the setup code for the CSR test.
 
-  Args:
-    test_file: the file containing the generated assembly code.
-  """
-  test_file.write(".macro init\n")
-  test_file.write(".endm\n")
-  test_file.write(".section .text.init\n")
-  test_file.write(".globl _start\n")
-  test_file.write(".option norvc\n")
-  test_file.write("_start:\n")
+    Args:
+      test_file: the file containing the generated assembly code.
+    """
+    test_file.write(".macro init\n")
+    test_file.write(".endm\n")
+    test_file.write(".section .text.init\n")
+    test_file.write(".globl _start\n")
+    test_file.write(".option norvc\n")
+    test_file.write("_start:\n")
 
 
 def gen_csr_test_fail(test_file, end_addr):
-  """
-  Generates code to handle a test failure.
-  This code consists of writing 1 to the GP register in an infinite loop.
-  The testbench will poll this register at the end of the test to detect failure.
+    """
+    Generates code to handle a test failure.
+    This code consists of writing 1 to the GP register in an infinite loop.
+    The testbench will poll this register at the end of the test to detect failure.
 
-  Args:
-    test_file: the file containing the generated assembly test code.
-    end_addr: address that should be written to at end of test
-  """
-  test_file.write("csr_fail:\n")
-  test_file.write("\tli x1, {}\n".format(TEST_FAIL))
-  test_file.write("\tslli x1, x1, 8\n")
-  test_file.write("\taddi x1, x1, {}\n".format(TEST_RESULT))
-  test_file.write("\tli x2, 0x{}\n".format(end_addr))
-  test_file.write("\tsw x1, 0(x2)\n")
-  test_file.write("\tj csr_fail\n")
+    Args:
+      test_file: the file containing the generated assembly test code.
+      end_addr: address that should be written to at end of test
+    """
+    test_file.write("csr_fail:\n")
+    test_file.write("\tli x1, {}\n".format(TEST_FAIL))
+    test_file.write("\tslli x1, x1, 8\n")
+    test_file.write("\taddi x1, x1, {}\n".format(TEST_RESULT))
+    test_file.write("\tli x2, 0x{}\n".format(end_addr))
+    test_file.write("\tsw x1, 0(x2)\n")
+    test_file.write("\tj csr_fail\n")
 
 
 def gen_csr_test_pass(test_file, end_addr):
-  """
-  Generates code to handle test success.
-  This code consists of writing 2 to the GP register in an infinite loop.
-  The testbench will poll this register at the end of the test to detect success.
+    """
+    Generates code to handle test success.
+    This code consists of writing 2 to the GP register in an infinite loop.
+    The testbench will poll this register at the end of the test to detect success.
 
-  Args:
-    test_file: the file containing the generated assembly test code.
-    end_addr: address that should be written to at end of test
-  """
-  test_file.write("csr_pass:\n")
-  test_file.write("\tli x1, {}\n".format(TEST_PASS))
-  test_file.write("\tslli x1, x1, 8\n")
-  test_file.write("\taddi x1, x1, {}\n".format(TEST_RESULT))
-  test_file.write("\tli x2, 0x{}\n".format(end_addr))
-  test_file.write("\tsw x1, 0(x2)\n")
-  test_file.write("\tj csr_pass\n")
+    Args:
+      test_file: the file containing the generated assembly test code.
+      end_addr: address that should be written to at end of test
+    """
+    test_file.write("csr_pass:\n")
+    test_file.write("\tli x1, {}\n".format(TEST_PASS))
+    test_file.write("\tslli x1, x1, 8\n")
+    test_file.write("\taddi x1, x1, {}\n".format(TEST_RESULT))
+    test_file.write("\tli x2, 0x{}\n".format(end_addr))
+    test_file.write("\tsw x1, 0(x2)\n")
+    test_file.write("\tj csr_pass\n")
 
 
 def gen_csr_instr(original_csr_map, csr_instructions, xlen,
                   iterations, out, end_signature_addr):
-  """
-  Uses the information in the map produced by get_csr_map() to generate
-  test CSR instructions operating on the generated random values.
+    """
+    Uses the information in the map produced by get_csr_map() to generate
+    test CSR instructions operating on the generated random values.
 
-  Args:
-    original_csr_map: The dictionary containing CSR mappings generated by get_csr_map()
-    csr_instructions: A list of all supported CSR instructions in string form.
-    xlen: The RISC-V ISA bit length.
-    iterations: Indicates how many randomized test files will be generated.
-    out: A string containing the directory path that the tests will be generated in.
-    end_signature_addr: The address the test should write to upon terminating
+    Args:
+      original_csr_map: The dictionary containing CSR mappings generated by get_csr_map()
+      csr_instructions: A list of all supported CSR instructions in string form.
+      xlen: The RISC-V ISA bit length.
+      iterations: Indicates how many randomized test files will be generated.
+      out: A string containing the directory path that the tests will be generated in.
+      end_signature_addr: The address the test should write to upon terminating
 
-  Returns:
-    No explicit return value, but will write the randomized assembly test code
-    to the specified number of files.
-  """
-  for i in range(iterations):
-    # pick two GPRs at random to act as source and destination registers
-    # for CSR operations
-    csr_map = copy.deepcopy(original_csr_map)
-    source_reg, dest_reg = ["x{}".format(i) for i in random.sample(range(1, 16), 2)]
-    csr_list = list(csr_map.keys())
-    with open("{}/riscv_csr_test_{}.S".format(out, i), "w") as csr_test_file:
-      gen_setup(csr_test_file)
-      for csr in csr_list:
-        csr_address, csr_val, csr_write_mask, csr_read_mask = csr_map.get(csr)
-        csr_test_file.write("\t# {}\n".format(csr))
-        for op in csr_instructions:
-          for i in range(3):
-            # hex string
-            rand_rs1_val = get_rs1_val(i, xlen)
-            # I type CSR instruction
-            first_li = ""
-            if op[-1] == "i":
-              imm = rand_rs1_val[-5:]
-              csr_inst = "\t{} {}, {}, 0b{}\n".format(op, dest_reg, csr_address, imm.bin)
-              imm_val = bitarray(uint=0, length=xlen-5)
-              imm_val.append(imm)
-              predict_li = ("\tli {}, "
-                "{}\n".format(source_reg, predict_csr_val(op, imm_val, csr_val, csr_write_mask, csr_read_mask)))
-            else:
-              first_li = "\tli {}, 0x{}\n".format(source_reg, rand_rs1_val.hex)
-              csr_inst = "\t{} {}, {}, {}\n".format(op, dest_reg, csr_address, source_reg)
-              predict_li = ("\tli {}, "
-                "{}\n".format(source_reg, predict_csr_val(op, rand_rs1_val, csr_val, csr_write_mask, csr_read_mask)))
-            branch_check = "\tbne {}, {}, csr_fail\n".format(source_reg, dest_reg)
-            csr_test_file.write(first_li)
-            csr_test_file.write(csr_inst)
-            csr_test_file.write(predict_li)
-            csr_test_file.write(branch_check)
-            """
+    Returns:
+      No explicit return value, but will write the randomized assembly test code
+      to the specified number of files.
+    """
+    for i in range(iterations):
+        # pick two GPRs at random to act as source and destination registers
+        # for CSR operations
+        csr_map = copy.deepcopy(original_csr_map)
+        source_reg, dest_reg = ["x{}".format(i) for i in
+                                random.sample(range(1, 16), 2)]
+        csr_list = list(csr_map.keys())
+        with open("{}/riscv_csr_test_{}.S".format(out, i),
+                  "w") as csr_test_file:
+            gen_setup(csr_test_file)
+            for csr in csr_list:
+                csr_address, csr_val, csr_write_mask, csr_read_mask = csr_map.get(
+                    csr)
+                csr_test_file.write("\t# {}\n".format(csr))
+                for op in csr_instructions:
+                    for i in range(3):
+                        # hex string
+                        rand_rs1_val = get_rs1_val(i, xlen)
+                        # I type CSR instruction
+                        first_li = ""
+                        if op[-1] == "i":
+                            imm = rand_rs1_val[-5:]
+                            csr_inst = "\t{} {}, {}, 0b{}\n".format(op,
+                                                                    dest_reg,
+                                                                    csr_address,
+                                                                    imm.bin)
+                            imm_val = bitarray(uint=0, length=xlen - 5)
+                            imm_val.append(imm)
+                            predict_li = ("\tli {}, "
+                                          "{}\n".format(source_reg,
+                                                        predict_csr_val(op,
+                                                                        imm_val,
+                                                                        csr_val,
+                                                                        csr_write_mask,
+                                                                        csr_read_mask)))
+                        else:
+                            first_li = "\tli {}, 0x{}\n".format(source_reg,
+                                                                rand_rs1_val.hex)
+                            csr_inst = "\t{} {}, {}, {}\n".format(op, dest_reg,
+                                                                  csr_address,
+                                                                  source_reg)
+                            predict_li = ("\tli {}, "
+                                          "{}\n".format(source_reg,
+                                                        predict_csr_val(op,
+                                                                        rand_rs1_val,
+                                                                        csr_val,
+                                                                        csr_write_mask,
+                                                                        csr_read_mask)))
+                        branch_check = "\tbne {}, {}, csr_fail\n".format(
+                            source_reg, dest_reg)
+                        csr_test_file.write(first_li)
+                        csr_test_file.write(csr_inst)
+                        csr_test_file.write(predict_li)
+                        csr_test_file.write(branch_check)
+                        """
             We must hardcode in one final CSR check, as the value that has last
             been written to the CSR has not been tested.
             """
-            if csr == csr_list[-1] and op == csr_instructions[-1] and i == 2:
-              final_csr_read = "\tcsrr {}, {}\n".format(dest_reg, csr_address)
-              csrrs_read_mask = bitarray(uint=0, length=xlen)
-              final_li = ("\tli {}, "
-                "{}\n".format(source_reg, predict_csr_val('csrrs', csrrs_read_mask, csr_val, csr_write_mask, csr_read_mask)))
-              final_branch_check = "\tbne {}, {}, csr_fail\n".format(source_reg, dest_reg)
-              csr_test_file.write(final_csr_read)
-              csr_test_file.write(final_li)
-              csr_test_file.write(final_branch_check)
-      gen_csr_test_pass(csr_test_file, end_signature_addr)
-      gen_csr_test_fail(csr_test_file, end_signature_addr)
+                        if csr == csr_list[-1] and op == csr_instructions[
+                            -1] and i == 2:
+                            final_csr_read = "\tcsrr {}, {}\n".format(dest_reg,
+                                                                      csr_address)
+                            csrrs_read_mask = bitarray(uint=0, length=xlen)
+                            final_li = ("\tli {}, "
+                                        "{}\n".format(source_reg,
+                                                      predict_csr_val('csrrs',
+                                                                      csrrs_read_mask,
+                                                                      csr_val,
+                                                                      csr_write_mask,
+                                                                      csr_read_mask)))
+                            final_branch_check = "\tbne {}, {}, csr_fail\n".format(
+                                source_reg, dest_reg)
+                            csr_test_file.write(final_csr_read)
+                            csr_test_file.write(final_li)
+                            csr_test_file.write(final_branch_check)
+            gen_csr_test_pass(csr_test_file, end_signature_addr)
+            gen_csr_test_fail(csr_test_file, end_signature_addr)
 
 
 def main():
-  """Main entry point of CSR test generation script.
+    """Main entry point of CSR test generation script.
      Will set up a list of all supported CSR instructions,
      and seed the RNG."""
 
-  # define command line arguments
-  parser = argparse.ArgumentParser()
-  parser.add_argument("--csr_file", type=str, default="yaml/csr_template.yaml",
-          help="The YAML file contating descriptions of all processor supported CSRs")
-  parser.add_argument("--xlen", type=int, default=32,
-          help="Specify the ISA width, e.g. 32 or 64 or 128")
-  parser.add_argument("--iterations", type=int, default=1,
-          help="Specify how many tests to be generated")
-  parser.add_argument("--out", type=str, default="./",
-          help="Specify output directory")
-  parser.add_argument("--end_signature_addr", type=str, default="0",
-          help="Address that should be written to at end of this test")
-  parser.add_argument("--seed", type=int, default=None,
-          help="""Value used to seed the random number generator. If no value is passed in,
+    # define command line arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--csr_file", type=str,
+                        default="yaml/csr_template.yaml",
+                        help="The YAML file contating descriptions of all processor supported CSRs")
+    parser.add_argument("--xlen", type=int, default=32,
+                        help="Specify the ISA width, e.g. 32 or 64 or 128")
+    parser.add_argument("--iterations", type=int, default=1,
+                        help="Specify how many tests to be generated")
+    parser.add_argument("--out", type=str, default="./",
+                        help="Specify output directory")
+    parser.add_argument("--end_signature_addr", type=str, default="0",
+                        help="Address that should be written to at end of this test")
+    parser.add_argument("--seed", type=int, default=None,
+                        help="""Value used to seed the random number generator. If no value is passed in,
                   the RNG will be seeded from an internal source of randomness.""")
-  args = parser.parse_args()
+    args = parser.parse_args()
 
-  """All supported CSR operations"""
-  csr_ops = ['csrrw', 'csrrs', 'csrrc', 'csrrwi', 'csrrsi', 'csrrci']
+    """All supported CSR operations"""
+    csr_ops = ['csrrw', 'csrrs', 'csrrc', 'csrrwi', 'csrrsi', 'csrrci']
 
-  """
-  Seed the RNG.
-  If args.seed is None, seed will be drawn from some internal random source.
-  If args.seed is defined, this will be used to seed the RNG for user reproducibility.
-  """
-  random.seed(args.seed)
+    """
+    Seed the RNG.
+    If args.seed is None, seed will be drawn from some internal random source.
+    If args.seed is defined, this will be used to seed the RNG for user reproducibility.
+    """
+    random.seed(args.seed)
 
-  gen_csr_instr(get_csr_map(args.csr_file, args.xlen),
-                csr_ops, args.xlen, args.iterations, args.out,
-                args.end_signature_addr)
+    gen_csr_instr(get_csr_map(args.csr_file, args.xlen),
+                  csr_ops, args.xlen, args.iterations, args.out,
+                  args.end_signature_addr)
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/scripts/instr_trace_compare.py
+++ b/scripts/instr_trace_compare.py
@@ -25,194 +25,201 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 
 from riscv_trace_csv import *
 
+
 def compare_trace_csv(csv1, csv2, name1, name2, log,
-                      in_order_mode = 1,
-                      coalescing_limit = 0,
-                      verbose = 0,
-                      mismatch_print_limit = 5,
-                      compare_final_value_only = 0):
-  """Compare two trace CSV file"""
-  matched_cnt = 0
-  mismatch_cnt = 0
-
-  # ensure that in order mode is disabled if necessary
-  if compare_final_value_only:
-    in_order_mode = 0
-
-  if log:
-    fd = open(log, 'a+')
-  else:
-    fd = sys.stdout
-
-  fd.write("%s : %s\n" % (name1, csv1))
-  fd.write("%s : %s\n" % (name2, csv2))
-
-  with open(csv1, "r") as fd1, open(csv2, "r") as fd2:
-    instr_trace_1 = []
-    instr_trace_2 = []
-    trace_csv_1 = RiscvInstructionTraceCsv(fd1)
-    trace_csv_2 = RiscvInstructionTraceCsv(fd2)
-    trace_csv_1.read_trace(instr_trace_1)
-    trace_csv_2.read_trace(instr_trace_2)
-    trace_1_index = 0
-    trace_2_index = 0
-    mismatch_cnt = 0
+                      in_order_mode=1,
+                      coalescing_limit=0,
+                      verbose=0,
+                      mismatch_print_limit=5,
+                      compare_final_value_only=0):
+    """Compare two trace CSV file"""
     matched_cnt = 0
-    if in_order_mode:
-      gpr_val_1 = {}
-      gpr_val_2 = {}
-      for trace in instr_trace_1:
-        trace_1_index += 1
-        if len(trace.gpr) == 0:
-          continue
-        # Check if there's a GPR change caused by this instruction
-        gpr_state_change_1 = check_update_gpr(trace.gpr, gpr_val_1)
-        if gpr_state_change_1 == 0:
-          continue
-        # Move forward the other trace until a GPR update happens
-        gpr_state_change_2 = 0
-        while (gpr_state_change_2 == 0 and trace_2_index < len(instr_trace_2)):
-          gpr_state_change_2 = check_update_gpr(instr_trace_2[trace_2_index].gpr,
-                                                gpr_val_2)
-          trace_2_index += 1
-        # Check if the GPR update is the same between trace 1 and 2
-        if gpr_state_change_2 == 0:
-          mismatch_cnt += 1
-          fd.write("Mismatch[%d]:\n[%d] %s : %s\n" %
-                   (mismatch_cnt, trace_1_index, name1, trace.get_trace_string()))
-          fd.write("%0d instructions left in trace %0s\n" %
-                   (len(instr_trace_1) - trace_1_index + 1, name1))
-        elif len(trace.gpr) != len(instr_trace_2[trace_2_index-1].gpr):
-          mismatch_cnt += 1
-          # print first few mismatches
-          if mismatch_cnt <= mismatch_print_limit:
-            fd.write("Mismatch[%d]:\n%s[%d] : %s\n" %
-                     (mismatch_cnt, name1, trace_2_index - 1,
-                     trace.get_trace_string()))
-            fd.write("%s[%d] : %s\n" %
-                     (name2, trace_2_index - 1,
-                     instr_trace_2[trace_2_index-1].get_trace_string()))
-        else:
-          found_mismatch = 0
-          for i in range(len(trace.gpr)):
-            if trace.gpr[i] != instr_trace_2[trace_2_index-1].gpr[i]:
-              mismatch_cnt += 1
-              found_mismatch = 1
-              # print first few mismatches
-              if mismatch_cnt <= mismatch_print_limit:
-                fd.write("Mismatch[%d]:\n%s[%d] : %s\n" %
-                         (mismatch_cnt, name1, trace_2_index - 1,
-                         trace.get_trace_string()))
-                fd.write("%s[%d] : %s\n" %
-                         (name2, trace_2_index - 1,
-                         instr_trace_2[trace_2_index-1].get_trace_string()))
-              break
-          if not found_mismatch:
-            matched_cnt += 1
-        # Break the loop if it reaches the end of trace 2
-        if trace_2_index == len(instr_trace_2):
-          break
-      # Check if there's remaining instruction that change architectural state
-      if trace_2_index != len(instr_trace_2):
-        while (trace_2_index < len(instr_trace_2)):
-          gpr_state_change_2 = check_update_gpr(
-                               instr_trace_2[trace_2_index].gpr,
-                               gpr_val_2)
-          if gpr_state_change_2 == 1:
-            fd.write("%0d instructions left in trace %0s\n" %
-                     (len(instr_trace_2) - trace_2_index, name2))
-            mismatch_cnt += len(instr_trace_2) - trace_2_index
-            break
-          trace_2_index += 1
-    else:
-      pass
-      # TODO: Enable out of order comparison
-#      # For processors which can commit multiple instructions in one cycle, the
-#      # ordering between different GPR update on that cycle could be
-#      # non-deterministic. If multiple instructions try to update the same GPR on
-#      # the same cycle, these updates could be coalesced to one update.
-#      gpr_trace_1 = {}
-#      gpr_trace_2 = {}
-#      parse_gpr_update_from_trace(instr_trace_1, gpr_trace_1)
-#      parse_gpr_update_from_trace(instr_trace_2, gpr_trace_2)
-#      if not compare_final_value_only:
-#        if len(gpr_trace_1) != len(gpr_trace_2):
-#          fd.write("Mismatch: affected GPR count mismtach %s:%d VS %s:%d\n" %
-#                   (name1, len(gpr_trace_1), name2, len(gpr_trace_2)))
-#          mismatch_cnt += 1
-#        for gpr in gpr_trace_1:
-#          coalesced_updates = 0
-#          if (len(gpr_trace_1[gpr]) != len(gpr_trace_2[gpr]) and
-#              coalescing_limit == 0):
-#            fd.write("Mismatch: GPR[%s] trace count mismtach %s:%d VS %s:%d\n" %
-#                     (gpr, name1, len(gpr_trace_1[gpr]),
-#                     name2, len(gpr_trace_2[gpr])))
-#            mismatch_cnt += 1
-#          trace_2_index = 0
-#          coalesced_updates = 0
-#          for trace_1_index in range(0, len(gpr_trace_1[gpr])-1):
-#            if (trace_2_index == len(gpr_trace_2[gpr])):
-#              break
-#            if int(gpr_trace_1[gpr][trace_1_index].rd_val, 16) != \
-#               int(gpr_trace_2[gpr][trace_2_index].rd_val, 16):
-#              if coalesced_updates >= coalescing_limit:
-#                coalesced_updates = 0
-#                mismatch_cnt += 1
-#                if mismatch_cnt <= mismatch_print_limit:
-#                  fd.write("Mismatch:\n")
-#                  fd.write("%s[%d] : %s\n" % (name1, trace_1_index,
-#                           gpr_trace_1[gpr][trace_1_index].get_trace_string()))
-#                  fd.write("%s[%d] : %s\n" % (name2, trace_2_index,
-#                           gpr_trace_2[gpr][trace_2_index].get_trace_string()))
-#                trace_2_index += 1
-#              else:
-#                if verbose:
-#                  fd.write("Skipping %s[%d] : %s\n" %
-#                           (name1, trace_1_index,
-#                           gpr_trace_1[gpr][trace_1_index].get_trace_string()))
-#                coalesced_updates += 1
-#            else:
-#              coalesced_updates = 0
-#              matched_cnt += 1
-#              if verbose:
-#                fd.write("Matched [%0d]: %s : %s\n" %
-#                         (trace_1_index, name1,
-#                         gpr_trace_1[gpr][trace_1_index].get_trace_string()))
-#              trace_2_index += 1
-#      # Check the final value match between the two traces
-#      for gpr in gpr_trace_1:
-#        if not compare_final_value_only:
-#          if (len(gpr_trace_1[gpr]) == 0 or len(gpr_trace_2[gpr]) == 0):
-#            mismatch_cnt += 1
-#            fd.write("Zero GPR[%s] updates observed: %s:%d, %s:%d\n" % (gpr,
-#                     name1, len(gpr_trace_1[gpr]), name2, len(gpr_trace_2[gpr])))
-#        else:
-#          if not gpr_trace_2.get(gpr):
-#            trace = RiscvInstructionTraceEntry()
-#            trace.rd_val = "0"
-#            trace.rd = gpr
-#            trace.instr_str = ""
-#            trace.binary = ""
-#            trace.addr = ""
-#            gpr_trace_2[gpr] = [trace]
-#        if int(gpr_trace_1[gpr][-1].rd_val, 16) != \
-#           int(gpr_trace_2[gpr][-1].rd_val, 16):
-#          mismatch_cnt += 1
-#          if mismatch_cnt <= mismatch_print_limit:
-#            fd.write("Mismatch final value:\n")
-#            fd.write("%s : %s\n" % (name1, gpr_trace_1[gpr][-1].get_trace_string()))
-#            fd.write("%s : %s\n" % (name2, gpr_trace_2[gpr][-1].get_trace_string()))
-    if mismatch_cnt == 0:
-      compare_result = "[PASSED]: %d matched\n" % ( matched_cnt)
-    else:
-      compare_result = "[FAILED]: %d matched, %d mismatch\n" % ( matched_cnt, mismatch_cnt)
-    fd.write(compare_result + "\n")
+    mismatch_cnt = 0
+
+    # ensure that in order mode is disabled if necessary
+    if compare_final_value_only:
+        in_order_mode = 0
+
     if log:
-      fd.close()
-    return compare_result
+        fd = open(log, 'a+')
+    else:
+        fd = sys.stdout
+
+    fd.write("{} : {}\n".format(name1, csv1))
+    fd.write("{} : {}\n".format(name2, csv2))
+
+    with open(csv1, "r") as fd1, open(csv2, "r") as fd2:
+        instr_trace_1 = []
+        instr_trace_2 = []
+        trace_csv_1 = RiscvInstructionTraceCsv(fd1)
+        trace_csv_2 = RiscvInstructionTraceCsv(fd2)
+        trace_csv_1.read_trace(instr_trace_1)
+        trace_csv_2.read_trace(instr_trace_2)
+        trace_1_index = 0
+        trace_2_index = 0
+        mismatch_cnt = 0
+        matched_cnt = 0
+        if in_order_mode:
+            gpr_val_1 = {}
+            gpr_val_2 = {}
+            for trace in instr_trace_1:
+                trace_1_index += 1
+                if len(trace.gpr) == 0:
+                    continue
+                # Check if there's a GPR change caused by this instruction
+                gpr_state_change_1 = check_update_gpr(trace.gpr, gpr_val_1)
+                if gpr_state_change_1 == 0:
+                    continue
+                # Move forward the other trace until a GPR update happens
+                gpr_state_change_2 = 0
+                while (gpr_state_change_2 == 0 and trace_2_index < len(
+                        instr_trace_2)):
+                    gpr_state_change_2 = check_update_gpr(
+                        instr_trace_2[trace_2_index].gpr,
+                        gpr_val_2)
+                    trace_2_index += 1
+                # Check if the GPR update is the same between trace 1 and 2
+                if gpr_state_change_2 == 0:
+                    mismatch_cnt += 1
+                    fd.write("Mismatch[{}]:\n[{}] {} : {}\n".format(
+                      mismatch_cnt, trace_1_index, name1,trace.get_trace_string()))
+                    fd.write("{} instructions left in trace {}\n".format(
+                      len(instr_trace_1) - trace_1_index + 1, name1))
+                elif len(trace.gpr) != len(
+                        instr_trace_2[trace_2_index - 1].gpr):
+                    mismatch_cnt += 1
+                    # print first few mismatches
+                    if mismatch_cnt <= mismatch_print_limit:
+                        fd.write("Mismatch[{}]:\n{}[{}] : {}\n".format(
+                          mismatch_cnt, name1, trace_2_index - 1,
+                          trace.get_trace_string()))
+                        fd.write("{}[{}] : {}\n".format(
+                          name2, trace_2_index - 1,
+                          instr_trace_2[
+                            trace_2_index - 1].get_trace_string()))
+                else:
+                    found_mismatch = 0
+                    for i in range(len(trace.gpr)):
+                        if trace.gpr[i] != instr_trace_2[trace_2_index - 1].gpr[i]:
+                            mismatch_cnt += 1
+                            found_mismatch = 1
+                            # print first few mismatches
+                            if mismatch_cnt <= mismatch_print_limit:
+                                fd.write("Mismatch[{}]:\n{}[{}] : {}\n".format(
+                                    mismatch_cnt, name1, trace_2_index - 1,
+                                    trace.get_trace_string()))
+                                fd.write("{}[{}] : {}\n".format(
+                                    name2, trace_2_index - 1,
+                                    instr_trace_2[
+                                        trace_2_index - 1].get_trace_string()))
+                            break
+                    if not found_mismatch:
+                        matched_cnt += 1
+                # Break the loop if it reaches the end of trace 2
+                if trace_2_index == len(instr_trace_2):
+                    break
+            # Check if there's remaining instruction that change architectural state
+            if trace_2_index != len(instr_trace_2):
+                while trace_2_index < len(instr_trace_2):
+                    gpr_state_change_2 = check_update_gpr(
+                        instr_trace_2[trace_2_index].gpr,
+                        gpr_val_2)
+                    if gpr_state_change_2 == 1:
+                        fd.write("{} instructions left in trace {}\n".format(
+                          len(instr_trace_2) - trace_2_index, name2))
+                        mismatch_cnt += len(instr_trace_2) - trace_2_index
+                        break
+                    trace_2_index += 1
+        else:
+            pass
+            # TODO: Enable out of order comparison
+          #      # For processors which can commit multiple instructions in one cycle, the
+          #      # ordering between different GPR update on that cycle could be
+          #      # non-deterministic. If multiple instructions try to update the same GPR on
+          #      # the same cycle, these updates could be coalesced to one update.
+          #      gpr_trace_1 = {}
+          #      gpr_trace_2 = {}
+          #      parse_gpr_update_from_trace(instr_trace_1, gpr_trace_1)
+          #      parse_gpr_update_from_trace(instr_trace_2, gpr_trace_2)
+          #      if not compare_final_value_only:
+          #        if len(gpr_trace_1) != len(gpr_trace_2):
+          #          fd.write("Mismatch: affected GPR count mismtach %s:%d VS %s:%d\n" %
+          #                   (name1, len(gpr_trace_1), name2, len(gpr_trace_2)))
+          #          mismatch_cnt += 1
+          #        for gpr in gpr_trace_1:
+          #          coalesced_updates = 0
+          #          if (len(gpr_trace_1[gpr]) != len(gpr_trace_2[gpr]) and
+          #              coalescing_limit == 0):
+          #            fd.write("Mismatch: GPR[%s] trace count mismtach %s:%d VS %s:%d\n" %
+          #                     (gpr, name1, len(gpr_trace_1[gpr]),
+          #                     name2, len(gpr_trace_2[gpr])))
+          #            mismatch_cnt += 1
+          #          trace_2_index = 0
+          #          coalesced_updates = 0
+          #          for trace_1_index in range(0, len(gpr_trace_1[gpr])-1):
+          #            if (trace_2_index == len(gpr_trace_2[gpr])):
+          #              break
+          #            if int(gpr_trace_1[gpr][trace_1_index].rd_val, 16) != \
+          #               int(gpr_trace_2[gpr][trace_2_index].rd_val, 16):
+          #              if coalesced_updates >= coalescing_limit:
+          #                coalesced_updates = 0
+          #                mismatch_cnt += 1
+          #                if mismatch_cnt <= mismatch_print_limit:
+          #                  fd.write("Mismatch:\n")
+          #                  fd.write("%s[%d] : %s\n" % (name1, trace_1_index,
+          #                           gpr_trace_1[gpr][trace_1_index].get_trace_string()))
+          #                  fd.write("%s[%d] : %s\n" % (name2, trace_2_index,
+          #                           gpr_trace_2[gpr][trace_2_index].get_trace_string()))
+          #                trace_2_index += 1
+          #              else:
+          #                if verbose:
+          #                  fd.write("Skipping %s[%d] : %s\n" %
+          #                           (name1, trace_1_index,
+          #                           gpr_trace_1[gpr][trace_1_index].get_trace_string()))
+          #                coalesced_updates += 1
+          #            else:
+          #              coalesced_updates = 0
+          #              matched_cnt += 1
+          #              if verbose:
+          #                fd.write("Matched [%0d]: %s : %s\n" %
+          #                         (trace_1_index, name1,
+          #                         gpr_trace_1[gpr][trace_1_index].get_trace_string()))
+          #              trace_2_index += 1
+          #      # Check the final value match between the two traces
+          #      for gpr in gpr_trace_1:
+          #        if not compare_final_value_only:
+          #          if (len(gpr_trace_1[gpr]) == 0 or len(gpr_trace_2[gpr]) == 0):
+          #            mismatch_cnt += 1
+          #            fd.write("Zero GPR[%s] updates observed: %s:%d, %s:%d\n" % (gpr,
+          #                     name1, len(gpr_trace_1[gpr]), name2, len(gpr_trace_2[gpr])))
+          #        else:
+          #          if not gpr_trace_2.get(gpr):
+          #            trace = RiscvInstructionTraceEntry()
+          #            trace.rd_val = "0"
+          #            trace.rd = gpr
+          #            trace.instr_str = ""
+          #            trace.binary = ""
+          #            trace.addr = ""
+          #            gpr_trace_2[gpr] = [trace]
+          #        if int(gpr_trace_1[gpr][-1].rd_val, 16) != \
+          #           int(gpr_trace_2[gpr][-1].rd_val, 16):
+          #          mismatch_cnt += 1
+          #          if mismatch_cnt <= mismatch_print_limit:
+          #            fd.write("Mismatch final value:\n")
+          #            fd.write("%s : %s\n" % (name1, gpr_trace_1[gpr][-1].get_trace_string()))
+          #            fd.write("%s : %s\n" % (name2, gpr_trace_2[gpr][-1].get_trace_string()))
+        if mismatch_cnt == 0:
+            compare_result = "[PASSED]: {} matched\n".format(matched_cnt)
+        else:
+            compare_result = "[FAILED]: {} matched, {} mismatch\n".format(
+                matched_cnt, mismatch_cnt)
+        fd.write(compare_result + "\n")
+        if log:
+            fd.close()
+        return compare_result
 
 
-#def parse_gpr_update_from_trace(trace_csv, gpr_trace):
+# def parse_gpr_update_from_trace(trace_csv, gpr_trace):
 #  prev_val = {}
 #  for trace in trace_csv:
 #    if trace.rd != "":
@@ -225,57 +232,61 @@ def compare_trace_csv(csv1, csv2, name1, name2, log,
 
 
 def check_update_gpr(gpr_update, gpr):
-  gpr_state_change = 0
-  for update in gpr_update:
-    if update == "":
-      return 0
-    item = update.split(":")
-    if len(item) != 2:
-      sys.exit("Illegal GPR update format:" + update)
-    rd = item[0]
-    rd_val = item[1]
-    if rd in gpr:
-      if rd_val != gpr[rd]:
-        gpr_state_change = 1
-    else:
-      if int(rd_val, 16) != 0:
-        gpr_state_change = 1
-    gpr[rd] = rd_val
-  return gpr_state_change
+    gpr_state_change = 0
+    for update in gpr_update:
+        if update == "":
+            return 0
+        item = update.split(":")
+        if len(item) != 2:
+            sys.exit("Illegal GPR update format:" + update)
+        rd = item[0]
+        rd_val = item[1]
+        if rd in gpr:
+            if rd_val != gpr[rd]:
+                gpr_state_change = 1
+        else:
+            if int(rd_val, 16) != 0:
+                gpr_state_change = 1
+        gpr[rd] = rd_val
+    return gpr_state_change
 
 
 def main():
-  # Parse input arguments
-  parser = argparse.ArgumentParser()
-  parser.add_argument("--csv_file_1", type=str, help="Instruction trace 1 CSV")
-  parser.add_argument("--csv_file_2", type=str, help="Instruction trace 2 CSV")
-  parser.add_argument("--csv_name_1", type=str, help="Instruction trace 1 name")
-  parser.add_argument("--csv_name_2", type=str, help="Instruction trace 2 name")
-  # optional arguments
-  parser.add_argument("--log", type=str, default="",
-                      help="Log file")
-  parser.add_argument("--in_order_mode", type=int, default=1,
-                      help="In order comparison mode")
-  parser.add_argument("--gpr_update_coalescing_limit", type=int, default=1,
-                      help="Allow the core to merge multiple updates to the \
+    # Parse input arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--csv_file_1", type=str,
+                        help="Instruction trace 1 CSV")
+    parser.add_argument("--csv_file_2", type=str,
+                        help="Instruction trace 2 CSV")
+    parser.add_argument("--csv_name_1", type=str,
+                        help="Instruction trace 1 name")
+    parser.add_argument("--csv_name_2", type=str,
+                        help="Instruction trace 2 name")
+    # optional arguments
+    parser.add_argument("--log", type=str, default="",
+                        help="Log file")
+    parser.add_argument("--in_order_mode", type=int, default=1,
+                        help="In order comparison mode")
+    parser.add_argument("--gpr_update_coalescing_limit", type=int, default=1,
+                        help="Allow the core to merge multiple updates to the \
                             same GPR into one. This option only applies to \
                             trace 2")
-  parser.add_argument("--mismatch_print_limit", type=int, default=5,
-                      help="Max number of mismatches printed")
-  parser.add_argument("--verbose", type=int, default=0,
-                      help="Verbose logging")
-  parser.add_argument("--compare_final_value_only", type=int, default=0,
-                      help="Only compare the final value of the GPR")
+    parser.add_argument("--mismatch_print_limit", type=int, default=5,
+                        help="Max number of mismatches printed")
+    parser.add_argument("--verbose", type=int, default=0,
+                        help="Verbose logging")
+    parser.add_argument("--compare_final_value_only", type=int, default=0,
+                        help="Only compare the final value of the GPR")
 
-  args = parser.parse_args()
+    args = parser.parse_args()
 
-  # Compare trace CSV
-  compare_trace_csv(args.csv_file_1, args.csv_file_2,
-                    args.csv_name_1, args.csv_name_2, args.log,
-                    args.in_order_mode, args.gpr_update_coalescing_limit,
-                    args.verbose, args.mismatch_print_limit,
-                    args.compare_final_value_only)
+    # Compare trace CSV
+    compare_trace_csv(args.csv_file_1, args.csv_file_2,
+                      args.csv_name_1, args.csv_name_2, args.log,
+                      args.in_order_mode, args.gpr_update_coalescing_limit,
+                      args.verbose, args.mismatch_print_limit,
+                      args.compare_final_value_only)
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -31,197 +31,207 @@ RET_SUCCESS = 0
 RET_FAIL    = 1
 RET_FATAL   = -1
 
-def setup_logging(verbose):
-  """Setup the root logger.
 
-  Args:
-    verbose: Verbose logging
-  """
-  if verbose:
-    logging.basicConfig(format="%(asctime)s %(filename)s:%(lineno)-5s %(levelname)-8s %(message)s",
-                        datefmt='%a, %d %b %Y %H:%M:%S',
-                        level=logging.DEBUG)
-  else:
-    logging.basicConfig(format="%(asctime)s %(levelname)-8s %(message)s",
-                        datefmt='%a, %d %b %Y %H:%M:%S',
-                        level=logging.INFO)
+def setup_logging(verbose):
+    """Setup the root logger.
+
+    Args:
+      verbose: Verbose logging
+    """
+    if verbose:
+        logging.basicConfig(
+            format="%(asctime)s %(filename)s:%(lineno)-5s %(levelname)-8s %(message)s",
+            datefmt='%a, %d %b %Y %H:%M:%S',
+            level=logging.DEBUG)
+    else:
+        logging.basicConfig(format="%(asctime)s %(levelname)-8s %(message)s",
+                            datefmt='%a, %d %b %Y %H:%M:%S',
+                            level=logging.INFO)
 
 
 def read_yaml(yaml_file):
-  """ Read YAML file to a dictionary
+    """ Read YAML file to a dictionary
 
-  Args:
-    yaml_file : YAML file
+    Args:
+      yaml_file : YAML file
 
-  Returns:
-    yaml_data : data read from YAML in dictionary format
-  """
-  with open(yaml_file, "r") as f:
+    Returns:
+      yaml_data : data read from YAML in dictionary format
+    """
+    with open(yaml_file, "r") as f:
+        try:
+            yaml_data = yaml.safe_load(f)
+        except yaml.YAMLError as exc:
+            logging.error(exc)
+            sys.exit(RET_FAIL)
+    return yaml_data
+
+
+def get_env_var(var, debug_cmd=None):
+    """Get the value of environment variable
+
+    Args:
+      var : Name of the environment variable
+
+    Returns:
+      val : Value of the environment variable
+    """
     try:
-      yaml_data = yaml.safe_load(f)
-    except yaml.YAMLError as exc:
-      logging.error(exc)
-      sys.exit(RET_FAIL)
-  return yaml_data
+        val = os.environ[var]
+    except KeyError:
+        if debug_cmd:
+            return var
+        else:
+            logging.warning("Please set the environment variable {}".format(var))
+            sys.exit(RET_FAIL)
+    return val
 
 
-def get_env_var(var, debug_cmd = None):
-  """Get the value of environment variable
+def run_cmd(cmd, timeout_s=999, exit_on_error=1, check_return_code=True,
+            debug_cmd=None):
+    """Run a command and return output
 
-  Args:
-    var : Name of the environment variable
+    Args:
+      cmd : shell command to run
 
-  Returns:
-    val : Value of the environment variable
-  """
-  try:
-    val = os.environ[var]
-  except KeyError:
+    Returns:
+      command output
+    """
+    logging.debug(cmd)
     if debug_cmd:
-      return var
-    else:
-      logging.warning("Please set the environment variable %0s" % var)
-      sys.exit(RET_FAIL)
-  return val
-
-
-def run_cmd(cmd, timeout_s = 999, exit_on_error = 1, check_return_code = True, debug_cmd = None):
-  """Run a command and return output
-
-  Args:
-    cmd : shell command to run
-
-  Returns:
-    command output
-  """
-  logging.debug(cmd)
-  if debug_cmd:
-      debug_cmd.write(cmd)
-      debug_cmd.write("\n\n")
-      return
-  try:
-    ps = subprocess.Popen("exec " + cmd,
-                          shell=True,
-                          executable='/bin/bash',
-                          universal_newlines=True,
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.STDOUT)
-  except subprocess.CalledProcessError:
-    logging.error(ps.communicate()[0])
-    sys.exit(RET_FAIL)
-  except KeyboardInterrupt:
-    logging.info("\nExited Ctrl-C from user request.")
-    sys.exit(130)
-  try:
-    output = ps.communicate(timeout = timeout_s)[0]
-  except subprocess.TimeoutExpired:
-    logging.error("Timeout[%ds]: %s" % (timeout_s, cmd))
-    output = ""
-    ps.kill()
-  rc = ps.returncode
-  if rc and check_return_code and rc > 0:
-    logging.info(output)
-    logging.error("ERROR return code: %d/%d, cmd:%s" % (check_return_code, rc, cmd))
-    if exit_on_error:
-      sys.exit(RET_FAIL)
-  logging.debug(output)
-  return output
-
-
-def run_parallel_cmd(cmd_list, timeout_s = 999, exit_on_error = 0,
-                     check_return_code = True, debug_cmd = None):
-  """Run a list of commands in parallel
-
-  Args:
-    cmd_list: command list
-
-  Returns:
-    command output
-  """
-  if debug_cmd:
-    for cmd in cmd_list:
-      debug_cmd.write(cmd)
-      debug_cmd.write("\n\n")
-    return
-  children = []
-  for cmd in cmd_list:
-    ps = subprocess.Popen("exec " + cmd,
-                          shell=True,
-                          executable='/bin/bash',
-                          universal_newlines=True,
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.STDOUT)
-    children.append(ps)
-  for i in range(len(children)):
-    logging.info("Command progress: %d/%d" % (i, len(children)))
-    logging.debug("Waiting for command: %s" % cmd_list[i])
+        debug_cmd.write(cmd)
+        debug_cmd.write("\n\n")
+        return
     try:
-      output = children[i].communicate(timeout = timeout_s)[0]
-    except KeyboardInterrupt:
-      logging.info("\nExited Ctrl-C from user request.")
-      sys.exit(130)
-    except subprocess.TimeoutExpired:
-      logging.error("Timeout[%ds]: %s" % (timeout_s, cmd))
-      children[i].kill()
-    rc = children[i].returncode
-    if rc and check_return_code and rc > 0:
-      logging.info(output)
-      logging.error("ERROR return code: %d, cmd:%s" % (rc, cmd))
-      if exit_on_error:
+        ps = subprocess.Popen("exec " + cmd,
+                              shell=True,
+                              executable='/bin/bash',
+                              universal_newlines=True,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError:
+        logging.error(ps.communicate()[0])
         sys.exit(RET_FAIL)
-    # Restore stty setting otherwise the terminal may go crazy
-    os.system("stty sane")
+    except KeyboardInterrupt:
+        logging.info("\nExited Ctrl-C from user request.")
+        sys.exit(130)
+    try:
+        output = ps.communicate(timeout=timeout_s)[0]
+    except subprocess.TimeoutExpired:
+        logging.error("Timeout[{}s]: {}".format(timeout_s, cmd))
+        output = ""
+        ps.kill()
+    rc = ps.returncode
+    if rc and check_return_code and rc > 0:
+        logging.info(output)
+        logging.error(
+            "ERROR return code: {}/{}, cmd:{}".format(check_return_code, rc, cmd))
+        if exit_on_error:
+            sys.exit(RET_FAIL)
     logging.debug(output)
+    return output
 
-def run_cmd_output(cmd, debug_cmd = None):
-  """Run a command and return output
-  Args:
-    cmd          : Command line to execute
-  """
-  logging.debug(" ".join(cmd))
-  if debug_cmd:
-      debug_cmd.write(" ".join(cmd))
-      debug_cmd.write("\n\n")
-      return
-  try:
-    output = subprocess.check_output(cmd)
-  except subprocess.CalledProcessError as exc:
-    logging.debug(exc.output)
-    raise exc
-    sys.exit(RET_FAIL)
-  if output:
-    logging.debug(output)
 
-def process_regression_list(testlist, test, iterations, matched_list, riscv_dv_root):
-  """ Get the matched tests from the regression test list
+def run_parallel_cmd(cmd_list, timeout_s=999, exit_on_error=0,
+                     check_return_code=True, debug_cmd=None):
+    """Run a list of commands in parallel
 
-  Args:
-    testlist      : Regression test list
-    test          : Test to run, "all" means all tests in the list
-    iterations    : Number of iterations for each test
-    riscv_dv_root : Root directory of RISCV-DV
+    Args:
+      cmd_list: command list
 
-  Returns:
-    matched_list : A list of matched tests
-  """
-  logging.info("Processing regression test list : %s, test: %s" % (testlist, test))
-  yaml_data = read_yaml(testlist)
-  mult_test = test.split(',')
-  for entry in yaml_data:
-    if 'import' in entry:
-      sub_list = re.sub('<riscv_dv_root>', riscv_dv_root, entry['import'])
-      process_regression_list(sub_list, test, iterations, matched_list, riscv_dv_root)
-    else:
-      if (entry['test'] in mult_test) or (test == "all"):
-        if (iterations > 0 and  entry['iterations'] > 0):
-          entry['iterations'] = iterations
-        if entry['iterations'] > 0:
-          logging.info("Found matched tests: %s, iterations:%0d" %
-                      (entry['test'], entry['iterations']))
-          matched_list.append(entry)
+    Returns:
+      command output
+    """
+    if debug_cmd:
+        for cmd in cmd_list:
+            debug_cmd.write(cmd)
+            debug_cmd.write("\n\n")
+        return
+    children = []
+    for cmd in cmd_list:
+        ps = subprocess.Popen("exec " + cmd,
+                              shell=True,
+                              executable='/bin/bash',
+                              universal_newlines=True,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.STDOUT)
+        children.append(ps)
+    for i in range(len(children)):
+        logging.info("Command progress: {}/{}".format(i, len(children)))
+        logging.debug("Waiting for command: {}".format(cmd_list[i]))
+        try:
+            output = children[i].communicate(timeout=timeout_s)[0]
+        except KeyboardInterrupt:
+            logging.info("\nExited Ctrl-C from user request.")
+            sys.exit(130)
+        except subprocess.TimeoutExpired:
+            logging.error("Timeout[{}s]: {}".format(timeout_s, cmd))
+            children[i].kill()
+        rc = children[i].returncode
+        if rc and check_return_code and rc > 0:
+            logging.info(output)
+            logging.error("ERROR return code: {}, cmd:{}".format(rc, cmd))
+            if exit_on_error:
+                sys.exit(RET_FAIL)
+        # Restore stty setting otherwise the terminal may go crazy
+        os.system("stty sane")
+        logging.debug(output)
 
-def create_output(output, noclean, prefix = "out_"):
-  """ Create output directory
+
+def run_cmd_output(cmd, debug_cmd=None):
+    """Run a command and return output
+    Args:
+      cmd          : Command line to execute
+    """
+    logging.debug(" ".join(cmd))
+    if debug_cmd:
+        debug_cmd.write(" ".join(cmd))
+        debug_cmd.write("\n\n")
+        return
+    try:
+        output = subprocess.check_output(cmd)
+    except subprocess.CalledProcessError as exc:
+        logging.debug(exc.output)
+        raise exc
+        sys.exit(RET_FAIL)
+    if output:
+        logging.debug(output)
+
+
+def process_regression_list(testlist, test, iterations, matched_list,
+                            riscv_dv_root):
+    """ Get the matched tests from the regression test list
+
+    Args:
+      testlist      : Regression test list
+      test          : Test to run, "all" means all tests in the list
+      iterations    : Number of iterations for each test
+      riscv_dv_root : Root directory of RISCV-DV
+
+    Returns:
+      matched_list : A list of matched tests
+    """
+    logging.info(
+        "Processing regression test list : {}, test: {}".format(testlist, test))
+    yaml_data = read_yaml(testlist)
+    mult_test = test.split(',')
+    for entry in yaml_data:
+        if 'import' in entry:
+            sub_list = re.sub('<riscv_dv_root>', riscv_dv_root, entry['import'])
+            process_regression_list(sub_list, test, iterations, matched_list,
+                                    riscv_dv_root)
+        else:
+            if (entry['test'] in mult_test) or (test == "all"):
+                if iterations > 0 and entry['iterations'] > 0:
+                    entry['iterations'] = iterations
+                if entry['iterations'] > 0:
+                    logging.info("Found matched tests: {}, iterations:{}".format(
+                      entry['test'], entry['iterations']))
+                    matched_list.append(entry)
+
+
+def create_output(output, noclean, prefix="out_"):
+    """ Create output directory
 
   Args:
     output : Name of specified output directory
@@ -230,187 +240,191 @@ def create_output(output, noclean, prefix = "out_"):
   Returns:
     Output directory
   """
-  # Create output directory
-  if output is None:
-    output = prefix + str(date.today())
-  if noclean is False:
-    os.system("rm -rf %s" % output)
+    # Create output directory
+    if output is None:
+        output = prefix + str(date.today())
+    if noclean is False:
+        os.system("rm -rf {}".format(output))
 
-  logging.info("Creating output directory: %s" % output)
-  subprocess.run(["mkdir", "-p", output])
-  return output
+    logging.info("Creating output directory: {}".format(output))
+    subprocess.run(["mkdir", "-p", output])
+    return output
+
 
 def gpr_to_abi(gpr):
-  """Convert a general purpose register to its corresponding abi name"""
-  switcher = {
-    "x0"  : "zero",
-    "x1"  : "ra",
-    "x2"  : "sp",
-    "x3"  : "gp",
-    "x4"  : "tp",
-    "x5"  : "t0",
-    "x6"  : "t1",
-    "x7"  : "t2",
-    "x8"  : "s0",
-    "x9"  : "s1",
-    "x10" : "a0",
-    "x11" : "a1",
-    "x12" : "a2",
-    "x13" : "a3",
-    "x14" : "a4",
-    "x15" : "a5",
-    "x16" : "a6",
-    "x17" : "a7",
-    "x18" : "s2",
-    "x19" : "s3",
-    "x20" : "s4",
-    "x21" : "s5",
-    "x22" : "s6",
-    "x23" : "s7",
-    "x24" : "s8",
-    "x25" : "s9",
-    "x26" : "s10",
-    "x27" : "s11",
-    "x28" : "t3",
-    "x29" : "t4",
-    "x30" : "t5",
-    "x31" : "t6",
-    "f0"  : "ft0",
-    "f1"  : "ft1",
-    "f2"  : "ft2",
-    "f3"  : "ft3",
-    "f4"  : "ft4",
-    "f5"  : "ft5",
-    "f6"  : "ft6",
-    "f7"  : "ft7",
-    "f8"  : "fs0",
-    "f9"  : "fs1",
-    "f10" : "fa0",
-    "f11" : "fa1",
-    "f12" : "fa2",
-    "f13" : "fa3",
-    "f14" : "fa4",
-    "f15" : "fa5",
-    "f16" : "fa6",
-    "f17" : "fa7",
-    "f18" : "fs2",
-    "f19" : "fs3",
-    "f20" : "fs4",
-    "f21" : "fs5",
-    "f22" : "fs6",
-    "f23" : "fs7",
-    "f24" : "fs8",
-    "f25" : "fs9",
-    "f26" : "fs10",
-    "f27" : "fs11",
-    "f28" : "ft8",
-    "f29" : "ft9",
-    "f30" : "ft10",
-    "f31" : "ft11",
-  }
-  return switcher.get(gpr, "na")
+    """Convert a general purpose register to its corresponding abi name"""
+    switcher = {
+        "x0" : "zero",
+        "x1" : "ra",
+        "x2" : "sp",
+        "x3" : "gp",
+        "x4" : "tp",
+        "x5" : "t0",
+        "x6" : "t1",
+        "x7" : "t2",
+        "x8" : "s0",
+        "x9" : "s1",
+        "x10": "a0",
+        "x11": "a1",
+        "x12": "a2",
+        "x13": "a3",
+        "x14": "a4",
+        "x15": "a5",
+        "x16": "a6",
+        "x17": "a7",
+        "x18": "s2",
+        "x19": "s3",
+        "x20": "s4",
+        "x21": "s5",
+        "x22": "s6",
+        "x23": "s7",
+        "x24": "s8",
+        "x25": "s9",
+        "x26": "s10",
+        "x27": "s11",
+        "x28": "t3",
+        "x29": "t4",
+        "x30": "t5",
+        "x31": "t6",
+        "f0" : "ft0",
+        "f1" : "ft1",
+        "f2" : "ft2",
+        "f3" : "ft3",
+        "f4" : "ft4",
+        "f5" : "ft5",
+        "f6" : "ft6",
+        "f7" : "ft7",
+        "f8" : "fs0",
+        "f9" : "fs1",
+        "f10": "fa0",
+        "f11": "fa1",
+        "f12": "fa2",
+        "f13": "fa3",
+        "f14": "fa4",
+        "f15": "fa5",
+        "f16": "fa6",
+        "f17": "fa7",
+        "f18": "fs2",
+        "f19": "fs3",
+        "f20": "fs4",
+        "f21": "fs5",
+        "f22": "fs6",
+        "f23": "fs7",
+        "f24": "fs8",
+        "f25": "fs9",
+        "f26": "fs10",
+        "f27": "fs11",
+        "f28": "ft8",
+        "f29": "ft9",
+        "f30": "ft10",
+        "f31": "ft11",
+    }
+    return switcher.get(gpr, "na")
 
 
 def sint_to_hex(val):
-  """Signed integer to hex conversion"""
-  return str(hex((val + (1 << 32)) % (1 << 32)))
+    """Signed integer to hex conversion"""
+    return str(hex((val + (1 << 32)) % (1 << 32)))
 
-BASE_RE = re.compile(r"(?P<rd>[a-z0-9]+?),(?P<imm>[\-0-9]*?)\((?P<rs1>[a-z0-9]+?)\)")
+
+BASE_RE = re.compile(
+    r"(?P<rd>[a-z0-9]+?),(?P<imm>[\-0-9]*?)\((?P<rs1>[a-z0-9]+?)\)")
+
 
 def convert_pseudo_instr(instr_name, operands, binary):
-  """Convert pseudo instruction to regular instruction"""
-  if instr_name == "nop":
-    instr_name = "addi"
-    operands = "zero,zero,0"
-  elif instr_name == "mv":
-    instr_name = "addi"
-    operands = operands + ",0"
-  elif instr_name == "not":
-    instr_name = "xori"
-    operands = operands + ",-1"
-  elif instr_name == "neg":
-    instr_name = "sub"
-    o = operands.split(",")
-    operands = o[0] + ",zero," + o[1]
-  elif instr_name == "negw":
-    instr_name = "subw"
-    o = operands.split(",")
-    operands = o[0] + ",zero," + o[1]
-  elif instr_name == "sext.w":
-    instr_name = "addiw"
-    operands = operands + ",0"
-  elif instr_name == "seqz":
-    instr_name = "sltiu"
-    operands = operands + ",1"
-  elif instr_name == "snez":
-    instr_name = "sltu"
-    o = operands.split(",")
-    operands = o[0] + ",zero," + o[1]
-  elif instr_name == "sltz":
-    instr_name = "slt"
-    operands = operands + ",zero"
-  elif instr_name == "sgtz":
-    instr_name = "slt"
-    o = operands.split(",")
-    operands = o[0] + ",zero," + o[1]
-  elif instr_name in ["beqz", "bnez", "bgez", "bltz"]:
-    instr_name = instr_name[0:3]
-    o = operands.split(",")
-    operands = o[0] + ",zero," + o[1]
-  elif instr_name == "blez":
-    instr_name = "bge";
-    operands = "zero," + operands
-  elif instr_name == "bgtz":
-    instr_name = "blt";
-    operands = "zero," + operands
-  elif instr_name == "bgt":
-    instr_name = "blt";
-    o = operands.split(",")
-    operands = o[1] + "," + o[0] + "," + o[2]
-  elif instr_name == "ble":
-    instr_name = "bge";
-    o = operands.split(",")
-    operands = o[1] + "," + o[0] + "," + o[2]
-  elif instr_name == "bgtu":
-    instr_name = "bltu";
-    o = operands.split(",")
-    operands = o[1] + "," + o[0] + "," + o[2]
-  elif instr_name == "bleu":
-    instr_name = "bgeu";
-    o = operands.split(",")
-    operands = o[1] + "," + o[0] + "," + o[2]
-  elif instr_name == "csrr":
-    instr_name = "csrrw"
-    operands = operands + ",zero"
-  elif instr_name in ["csrw", "csrs", "csrc"]:
-    instr_name = "csrr" + instr_name[3:]
-    operands = "zero," + operands
-  elif instr_name in ["csrwi", "csrsi", "csrci"]:
-    instr_name = "csrr" + instr_name[3:]
-    operands = "zero," + operands
-  elif instr_name == "jr":
-    instr_name = "jalr"
-    operands = "zero,%s,0" % operands
-  elif instr_name == "j":
-    instr_name = "jal"
-    operands = "zero,%s" % operands
-  elif instr_name == "jal":
-    if not ("," in operands):
-      operands = "ra,%s" % operands
-  elif instr_name == "jalr":
-    m = BASE_RE.search(operands)
-    # jalr rd, imm(rs1)
-    if m:
-      operands = "%s,%s,%s" % (m.group("rd"), m.group("rs1"), m.group("imm"))
-    # jalr rs1
-    idx = operands.rfind(",")
-    if idx == -1:
-      operands = "ra," + operands + ",0"
-  elif instr_name == "ret":
-    if binary[-1] == "2":
-      instr_name = "c.jr"
-      operands = "ra"
-    else:
-      instr_name = "jalr"
-      operands = "zero,ra,0"
-  return instr_name, operands
+    """Convert pseudo instruction to regular instruction"""
+    if instr_name == "nop":
+        instr_name = "addi"
+        operands = "zero,zero,0"
+    elif instr_name == "mv":
+        instr_name = "addi"
+        operands = operands + ",0"
+    elif instr_name == "not":
+        instr_name = "xori"
+        operands = operands + ",-1"
+    elif instr_name == "neg":
+        instr_name = "sub"
+        o = operands.split(",")
+        operands = o[0] + ",zero," + o[1]
+    elif instr_name == "negw":
+        instr_name = "subw"
+        o = operands.split(",")
+        operands = o[0] + ",zero," + o[1]
+    elif instr_name == "sext.w":
+        instr_name = "addiw"
+        operands = operands + ",0"
+    elif instr_name == "seqz":
+        instr_name = "sltiu"
+        operands = operands + ",1"
+    elif instr_name == "snez":
+        instr_name = "sltu"
+        o = operands.split(",")
+        operands = o[0] + ",zero," + o[1]
+    elif instr_name == "sltz":
+        instr_name = "slt"
+        operands = operands + ",zero"
+    elif instr_name == "sgtz":
+        instr_name = "slt"
+        o = operands.split(",")
+        operands = o[0] + ",zero," + o[1]
+    elif instr_name in ["beqz", "bnez", "bgez", "bltz"]:
+        instr_name = instr_name[0:3]
+        o = operands.split(",")
+        operands = o[0] + ",zero," + o[1]
+    elif instr_name == "blez":
+        instr_name = "bge"
+        operands = "zero," + operands
+    elif instr_name == "bgtz":
+        instr_name = "blt"
+        operands = "zero," + operands
+    elif instr_name == "bgt":
+        instr_name = "blt"
+        o = operands.split(",")
+        operands = o[1] + "," + o[0] + "," + o[2]
+    elif instr_name == "ble":
+        instr_name = "bge"
+        o = operands.split(",")
+        operands = o[1] + "," + o[0] + "," + o[2]
+    elif instr_name == "bgtu":
+        instr_name = "bltu"
+        o = operands.split(",")
+        operands = o[1] + "," + o[0] + "," + o[2]
+    elif instr_name == "bleu":
+        instr_name = "bgeu"
+        o = operands.split(",")
+        operands = o[1] + "," + o[0] + "," + o[2]
+    elif instr_name == "csrr":
+        instr_name = "csrrw"
+        operands = operands + ",zero"
+    elif instr_name in ["csrw", "csrs", "csrc"]:
+        instr_name = "csrr" + instr_name[3:]
+        operands = "zero," + operands
+    elif instr_name in ["csrwi", "csrsi", "csrci"]:
+        instr_name = "csrr" + instr_name[3:]
+        operands = "zero," + operands
+    elif instr_name == "jr":
+        instr_name = "jalr"
+        operands = "zero,{},0".format(operands)
+    elif instr_name == "j":
+        instr_name = "jal"
+        operands = "zero,{}".format(operands)
+    elif instr_name == "jal":
+        if not ("," in operands):
+            operands = "ra,{}".format(operands)
+    elif instr_name == "jalr":
+        m = BASE_RE.search(operands)
+        # jalr rd, imm(rs1)
+        if m:
+            operands = "{},{},{}".format(m.group("rd"), m.group("rs1"), m.group("imm"))
+        # jalr rs1
+        idx = operands.rfind(",")
+        if idx == -1:
+            operands = "ra," + operands + ",0"
+    elif instr_name == "ret":
+        if binary[-1] == "2":
+            instr_name = "c.jr"
+            operands = "ra"
+        else:
+            instr_name = "jalr"
+            operands = "zero,ra,0"
+    return instr_name, operands

--- a/scripts/ovpsim_log_to_trace_csv.py
+++ b/scripts/ovpsim_log_to_trace_csv.py
@@ -27,186 +27,196 @@ from lib import *
 from riscv_trace_csv import *
 
 INSTR_RE = re.compile(r"riscvOVPsim.*, 0x(?P<addr>.*?)(?P<section>\(.*\): ?)" \
-                       "(?P<mode>[A-Za-z]*?)\s+(?P<bin>[a-f0-9]*?)\s+(?P<instr_str>.*?)$")
+                      "(?P<mode>[A-Za-z]*?)\s+(?P<bin>[a-f0-9]*?)\s+(?P<instr_str>.*?)$")
 RD_RE = re.compile(r" (?P<r>[a-z]*[0-9]{0,2}?) (?P<pre>[a-f0-9]+?)" \
-                    " -> (?P<val>[a-f0-9]+?)$")
-BASE_RE = re.compile(r"(?P<rd>[a-z0-9]+?),(?P<imm>[\-0-9]*?)\((?P<rs1>[a-z0-9]+?)\)")
+                   " -> (?P<val>[a-f0-9]+?)$")
+BASE_RE = re.compile(
+    r"(?P<rd>[a-z0-9]+?),(?P<imm>[\-0-9]*?)\((?P<rs1>[a-z0-9]+?)\)")
+
 
 def convert_mode(pri, line, stop_on_first_error=False):
-  """ OVPsim uses text string, convert to numeric """
-  if "Machine"    in pri:    return str(3)
-  if "Supervisor" in pri:    return str(1)
-  if "User"       in pri:    return str(0)
-  logging.error("convert_mode = UNKNOWN PRIV MODE  [%s]: %s" % (pri, line))
-  if stop_on_first_error:
-    sys.exit(RET_FATAL)
+    """ OVPsim uses text string, convert to numeric """
+    if "Machine" in pri:
+      return str(3)
+    if "Supervisor" in pri:
+      return str(1)
+    if "User" in pri:
+      return str(0)
+    logging.error("convert_mode = UNKNOWN PRIV MODE  [{}]: {}".format(pri, line))
+    if stop_on_first_error:
+        sys.exit(RET_FATAL)
+
 
 def is_csr(r):
-  """ see if r is a csr """
-  if len(r) > 4:
-    return True
-  elif r[0] in ["m", "u", "d"]:
-    return True
-  elif r in ["frm", "fcsr", "vl", "satp"]:
-    return True
-  else:
-    return False
+    """ see if r is a csr """
+    if len(r) > 4:
+        return True
+    elif r[0] in ["m", "u", "d"]:
+        return True
+    elif r in ["frm", "fcsr", "vl", "satp"]:
+        return True
+    else:
+        return False
+
 
 def process_ovpsim_sim_log(ovpsim_log, csv,
-                           stop_on_first_error = 0,
-                           dont_truncate_after_first_ecall = 0,
-                           full_trace = True):
-  """Process OVPsim simulation log.
+                           stop_on_first_error=0,
+                           dont_truncate_after_first_ecall=0,
+                           full_trace=True):
+    """Process OVPsim simulation log.
 
-  Extract instruction and affected register information from ovpsim simulation
-  log and save to a list.
-  """
-  logging.info("Processing ovpsim log : %s" % ovpsim_log)
+    Extract instruction and affected register information from ovpsim simulation
+    log and save to a list.
+    """
+    logging.info("Processing ovpsim log : {}".format(ovpsim_log))
 
-  # Remove the header part of ovpsim log
-  cmd = ("sed -i '/Info 1:/,$!d' %s" % ovpsim_log)
-  os.system(cmd)
-  # Remove all instructions after end of trace data (end of program excecution)
-  if dont_truncate_after_first_ecall:
-    cmd = ("sed -i '/^Info --/q' %s" % ovpsim_log)
-    logging.info("Dont truncate logfile after first ecall: %s", ovpsim_log)
-  else:
-    cmd = ("sed -i '/ecall/q' %s" % ovpsim_log)
-  os.system(cmd)
+    # Remove the header part of ovpsim log
+    cmd = ("sed -i '/Info 1:/,$!d' {}".format(ovpsim_log))
+    os.system(cmd)
+    # Remove all instructions after end of trace data (end of program excecution)
+    if dont_truncate_after_first_ecall:
+        cmd = ("sed -i '/^Info --/q' {}".format(ovpsim_log))
+        logging.info("Dont truncate logfile after first ecall: {}".format(ovpsim_log))
+    else:
+        cmd = ("sed -i '/ecall/q' {}".format(ovpsim_log))
+    os.system(cmd)
 
-  instr_cnt = 0
-  with open(ovpsim_log, "r") as f, open(csv, "w") as csv_fd:
-    trace_csv = RiscvInstructionTraceCsv(csv_fd)
-    trace_csv.start_new_trace()
-    prev_trace = 0
-    for line in f:
-      # Extract instruction infromation
-      m = INSTR_RE.search(line)
-      if m:
-        if prev_trace: # write out the previous one when find next one
-          trace_csv.write_trace_entry(prev_trace)
-          instr_cnt += 1
-          prev_trace = 0
-        prev_trace = RiscvInstructionTraceEntry()
-        prev_trace.instr_str = m.group("instr_str")
-        prev_trace.pc = m.group("addr")
-        prev_trace.mode = convert_mode(m.group("mode"), line)
-        prev_trace.binary = m.group("bin")
-        if full_trace:
-          prev_trace.instr = prev_trace.instr_str.split(" ")[0]
-          prev_trace.operand = prev_trace.instr_str[len(prev_trace.instr):]
-          prev_trace.operand = prev_trace.operand.replace(" ", "")
-          process_trace(prev_trace)
-        continue
-      # Extract register change value information
-      c = RD_RE.search(line)
-      if c:
-        if is_csr(c.group("r")):
-          prev_trace.csr.append(c.group("r") + ":" + c.group("val"))
-        else:
-          prev_trace.gpr.append(c.group("r") + ":" + c.group("val"))
-  logging.info("Processed instruction count : %d " % instr_cnt)
-  if instr_cnt == 0:
-    logging.error ("No Instructions in logfile: %s" % ovpsim_log)
-    sys.exit(RET_FATAL)
-  logging.info("CSV saved to : %s" % csv)
+    instr_cnt = 0
+    with open(ovpsim_log, "r") as f, open(csv, "w") as csv_fd:
+        trace_csv = RiscvInstructionTraceCsv(csv_fd)
+        trace_csv.start_new_trace()
+        prev_trace = 0
+        for line in f:
+            # Extract instruction infromation
+            m = INSTR_RE.search(line)
+            if m:
+                if prev_trace:  # write out the previous one when find next one
+                    trace_csv.write_trace_entry(prev_trace)
+                    instr_cnt += 1
+                    prev_trace = 0
+                prev_trace = RiscvInstructionTraceEntry()
+                prev_trace.instr_str = m.group("instr_str")
+                prev_trace.pc = m.group("addr")
+                prev_trace.mode = convert_mode(m.group("mode"), line)
+                prev_trace.binary = m.group("bin")
+                if full_trace:
+                    prev_trace.instr = prev_trace.instr_str.split(" ")[0]
+                    prev_trace.operand = prev_trace.instr_str[
+                                         len(prev_trace.instr):]
+                    prev_trace.operand = prev_trace.operand.replace(" ", "")
+                    process_trace(prev_trace)
+                continue
+            # Extract register change value information
+            c = RD_RE.search(line)
+            if c:
+                if is_csr(c.group("r")):
+                    prev_trace.csr.append(c.group("r") + ":" + c.group("val"))
+                else:
+                    prev_trace.gpr.append(c.group("r") + ":" + c.group("val"))
+    logging.info("Processed instruction count : {} ".format(instr_cnt))
+    if instr_cnt == 0:
+        logging.error("No Instructions in logfile: {}".format(ovpsim_log))
+        sys.exit(RET_FATAL)
+    logging.info("CSV saved to : {}".format(csv))
 
 
 def process_trace(trace):
-  """ Process instruction operands """
-  process_compressed_instr(trace)
-  process_imm(trace)
-  if trace.instr == "jalr":
-    process_jalr(trace)
-  trace.instr, trace.operand = convert_pseudo_instr(
-      trace.instr, trace.operand, trace.binary)
-  trace.operand = trace.operand.replace(")", "")
-  trace.operand = trace.operand.replace("(", ",")
+    """ Process instruction operands """
+    process_compressed_instr(trace)
+    process_imm(trace)
+    if trace.instr == "jalr":
+        process_jalr(trace)
+    trace.instr, trace.operand = convert_pseudo_instr(
+        trace.instr, trace.operand, trace.binary)
+    trace.operand = trace.operand.replace(")", "")
+    trace.operand = trace.operand.replace("(", ",")
 
 
 def process_imm(trace):
-  """ Process imm to follow RISC-V standard convention """
-  if trace.instr in ['beq', 'bne', 'blt', 'bge', 'bltu', 'bgeu', 'c.beqz',
-                     'c.bnez', 'beqz', 'bnez', 'bgez', 'bltz', 'blez', 'bgtz'
-                     'c.j', "j", "c.jal", "jal"]:
-    # convert from ovpsim logs branch/jump offsets as absolute to relative
-    idx = trace.operand.rfind(",")
-    if idx == -1:
-      imm = trace.operand
-      imm = str(sint_to_hex(int(imm, 16) - int(trace.pc, 16)))
-      trace.operand = imm
-    else:
-      imm = trace.operand[idx+1:]
-      imm = str(sint_to_hex(int(imm, 16) - int(trace.pc, 16)))
-      trace.operand = trace.operand[0:idx+1] + imm
+    """ Process imm to follow RISC-V standard convention """
+    if trace.instr in ['beq', 'bne', 'blt', 'bge', 'bltu', 'bgeu', 'c.beqz',
+                       'c.bnez', 'beqz', 'bnez', 'bgez', 'bltz', 'blez', 'bgtz',
+                       'c.j','j', 'c.jal', 'jal']:
+        # convert from ovpsim logs branch/jump offsets as absolute to relative
+        idx = trace.operand.rfind(",")
+        if idx == -1:
+            imm = trace.operand
+            imm = str(sint_to_hex(int(imm, 16) - int(trace.pc, 16)))
+            trace.operand = imm
+        else:
+            imm = trace.operand[idx + 1:]
+            imm = str(sint_to_hex(int(imm, 16) - int(trace.pc, 16)))
+            trace.operand = trace.operand[0:idx + 1] + imm
 
 
 def process_jalr(trace):
-  """ process jalr """
-  ## jalr x3
-  ## jalr 9(x3)
-  ## jalr x2,x3
-  ## jalr x2,4(x3)
-  idx = trace.operand.rfind(",")
-  if idx == -1:
-    # Add default destination register : ra
-    trace.operand = "ra," + trace.operand
-  m = BASE_RE.search(trace.operand)
-  if m:
-    # Convert pseudo JALR format to normal format
-    trace.operand = "%s,%s,%s" % (m.group("rd"), m.group("rs1"), m.group("imm"))
-  else:
-    # Add default imm 0
-    trace.operand = trace.operand + ",0"
+    """ process jalr """
+    ## jalr x3
+    ## jalr 9(x3)
+    ## jalr x2,x3
+    ## jalr x2,4(x3)
+    idx = trace.operand.rfind(",")
+    if idx == -1:
+        # Add default destination register : ra
+        trace.operand = "ra," + trace.operand
+    m = BASE_RE.search(trace.operand)
+    if m:
+        # Convert pseudo JALR format to normal format
+        trace.operand = "{},{},{}".format(
+        m.group("rd"), m.group("rs1"), m.group("imm"))
+    else:
+        # Add default imm 0
+        trace.operand = trace.operand + ",0"
 
 
 def process_compressed_instr(trace):
-  """ convert naming for compressed instructions """
-  trace_binary = int(trace.binary, 16)
-  o = trace.operand.split(",")
-  if len(trace.binary) == 4: # compressed are always 4 hex digits
-    trace.instr = "c." + trace.instr
-    if ("sp,sp," in trace.operand) and (trace.instr == "c.addi"):
-      trace.instr = "c.addi16sp"
-      idx = trace.operand.rfind(",")
-      trace.operand = "sp," + trace.operand[idx+1:]
-    elif (",sp," in trace.operand) and (trace.instr == "c.addi"):
-      trace.instr = "c.addi4spn"
-    elif ("(sp)" in trace.operand) and (trace_binary % 4 != 0):
-      trace.instr = trace.instr + "sp"
-    if not ("(" in trace.operand):
-      # OVPSIM use non-compressed instruction format in the trace,
-      # need to remove duplicated rs1/rd
-      if len(o) > 2:
-        trace.operand =  ",".join(o[1:])
-    if trace.instr == "c.jal":
-      trace.operand = o[1]
+    """ convert naming for compressed instructions """
+    trace_binary = int(trace.binary, 16)
+    o = trace.operand.split(",")
+    if len(trace.binary) == 4:  # compressed are always 4 hex digits
+        trace.instr = "c." + trace.instr
+        if ("sp,sp," in trace.operand) and (trace.instr == "c.addi"):
+            trace.instr = "c.addi16sp"
+            idx = trace.operand.rfind(",")
+            trace.operand = "sp," + trace.operand[idx + 1:]
+        elif (",sp," in trace.operand) and (trace.instr == "c.addi"):
+            trace.instr = "c.addi4spn"
+        elif ("(sp)" in trace.operand) and (trace_binary % 4 != 0):
+            trace.instr = trace.instr + "sp"
+        if not ("(" in trace.operand):
+            # OVPSIM use non-compressed instruction format in the trace,
+            # need to remove duplicated rs1/rd
+            if len(o) > 2:
+                trace.operand = ",".join(o[1:])
+        if trace.instr == "c.jal":
+            trace.operand = o[1]
 
 
 def main():
-  """ if used standalone set up for testing """
-  # Parse input arguments
-  parser = argparse.ArgumentParser()
-  parser.add_argument("--log", type=str, help="Input ovpsim simulation log")
-  parser.add_argument("--csv", type=str, help="Output trace csv_buf file")
-  parser.add_argument("--verbose", dest="verbose", action="store_true",
-                                         help="Verbose logging")
-  parser.add_argument("--stop_on_first_error", dest="stop_on_first_error",
-                                         action="store_true",
-                                         help="Stop on first error")
-  parser.add_argument("--dont_truncate_after_first_ecall",
-                                         dest="dont_truncate_after_first_ecall",
-                                         action="store_true",
-                                         help="Dont truncate on first ecall")
-  parser.set_defaults(verbose=False)
-  parser.set_defaults(stop_on_first_error=False)
-  parser.set_defaults(dont_truncate_after_first_ecall=False)
-  args = parser.parse_args()
-  # Process ovpsim log
-  process_ovpsim_sim_log(args.log,
-                         args.csv,
-                         args.stop_on_first_error,
-                         args.dont_truncate_after_first_ecall)
+    """ if used standalone set up for testing """
+    # Parse input arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log", type=str, help="Input ovpsim simulation log")
+    parser.add_argument("--csv", type=str, help="Output trace csv_buf file")
+    parser.add_argument("--verbose", dest="verbose", action="store_true",
+                        help="Verbose logging")
+    parser.add_argument("--stop_on_first_error", dest="stop_on_first_error",
+                        action="store_true",
+                        help="Stop on first error")
+    parser.add_argument("--dont_truncate_after_first_ecall",
+                        dest="dont_truncate_after_first_ecall",
+                        action="store_true",
+                        help="Dont truncate on first ecall")
+    parser.set_defaults(verbose=False)
+    parser.set_defaults(stop_on_first_error=False)
+    parser.set_defaults(dont_truncate_after_first_ecall=False)
+    args = parser.parse_args()
+    # Process ovpsim log
+    process_ovpsim_sim_log(args.log,
+                           args.csv,
+                           args.stop_on_first_error,
+                           args.dont_truncate_after_first_ecall)
+
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/scripts/riscv_trace_csv.py
+++ b/scripts/riscv_trace_csv.py
@@ -22,77 +22,80 @@ import logging
 import sys
 from lib import *
 
-class RiscvInstructionTraceEntry(object):
-  """RISC-V instruction trace entry"""
-  def __init__(self):
-    self.gpr = []
-    self.csr = []
-    self.instr = ""
-    self.operand = ""
-    self.pc = ""
-    self.binary = ""
-    self.instr_str = ""
-    self.mode = ""
 
-  def get_trace_string(self):
-    """Return a short string of the trace entry"""
-    return ("pc[%s] %s: %s %s" %
-            (self.pc, self.instr_str, " ".join(self.gpr), " ".join(self.csr)))
+class RiscvInstructionTraceEntry(object):
+    """RISC-V instruction trace entry"""
+
+    def __init__(self):
+        self.gpr = []
+        self.csr = []
+        self.instr = ""
+        self.operand = ""
+        self.pc = ""
+        self.binary = ""
+        self.instr_str = ""
+        self.mode = ""
+
+    def get_trace_string(self):
+        """Return a short string of the trace entry"""
+        return ("pc[{}] {}: {} {}".format(
+            self.pc, self.instr_str, " ".join(self.gpr), " ".join(self.csr)))
+
 
 class RiscvInstructionTraceCsv(object):
-  """RISC-V instruction trace CSV class
+    """RISC-V instruction trace CSV class
 
-  This class provides functions to read/write trace CSV
-  """
-  def __init__(self, csv_fd):
-    self.csv_fd = csv_fd
+    This class provides functions to read/write trace CSV
+    """
 
+    def __init__(self, csv_fd):
+        self.csv_fd = csv_fd
 
-  def start_new_trace(self):
-    """Create a CSV file handle for a new trace"""
-    fields = [
-        "pc", "instr", "gpr", "csr", "binary", "mode", "instr_str", "operand", "pad"]
-    self.csv_writer = csv.DictWriter(self.csv_fd, fieldnames=fields)
-    self.csv_writer.writeheader()
+    def start_new_trace(self):
+        """Create a CSV file handle for a new trace"""
+        fields = ["pc", "instr", "gpr", "csr", "binary", "mode", "instr_str",
+                  "operand", "pad"]
+        self.csv_writer = csv.DictWriter(self.csv_fd, fieldnames=fields)
+        self.csv_writer.writeheader()
 
+    def read_trace(self, trace):
+        """Read instruction trace from CSV file"""
+        csv_reader = csv.DictReader(self.csv_fd)
+        for row in csv_reader:
+            new_trace = RiscvInstructionTraceEntry()
+            new_trace.gpr = row['gpr'].split(';')
+            new_trace.csr = row['csr'].split(';')
+            new_trace.pc = row['pc']
+            new_trace.operand = row['operand']
+            new_trace.binary = row['binary']
+            new_trace.instr_str = row['instr_str']
+            new_trace.instr = row['instr']
+            new_trace.mode = row['mode']
+            trace.append(new_trace)
 
-  def read_trace(self, trace):
-    """Read instruction trace from CSV file"""
-    csv_reader = csv.DictReader(self.csv_fd)
-    for row in csv_reader:
-      new_trace = RiscvInstructionTraceEntry()
-      new_trace.gpr = row['gpr'].split(';')
-      new_trace.csr = row['csr'].split(';')
-      new_trace.pc = row['pc']
-      new_trace.operand = row['operand']
-      new_trace.binary = row['binary']
-      new_trace.instr_str = row['instr_str']
-      new_trace.instr = row['instr']
-      new_trace.mode = row['mode']
-      trace.append(new_trace)
+    # TODO: Convert pseudo instruction to regular instruction
 
-  # TODO: Convert pseudo instruction to regular instruction
+    def write_trace_entry(self, entry):
+        """Write a new trace entry to CSV"""
+        self.csv_writer.writerow({'instr_str': entry.instr_str,
+                                  'gpr'      : ";".join(entry.gpr),
+                                  'csr'      : ";".join(entry.csr),
+                                  'operand'  : entry.operand,
+                                  'pc'       : entry.pc,
+                                  'binary'   : entry.binary,
+                                  'instr'    : entry.instr,
+                                  'mode'     : entry.mode})
 
-  def write_trace_entry(self, entry):
-    """Write a new trace entry to CSV"""
-    self.csv_writer.writerow({'instr_str' : entry.instr_str,
-                              'gpr'       : ";".join(entry.gpr),
-                              'csr'       : ";".join(entry.csr),
-                              'operand'   : entry.operand,
-                              'pc'        : entry.pc,
-                              'binary'    : entry.binary,
-                              'instr'     : entry.instr,
-                              'mode'      : entry.mode})
 
 def get_imm_hex_val(imm):
-  """Get the hex representation of the imm value"""
-  if imm[0] == '-':
-    is_negative = 1
-    imm = imm[1:]
-  else:
-    is_negative = 0
-  imm_val = int(imm, 0)
-  if is_negative:
-    imm_val = -imm_val
-  hexstr = sint_to_hex(imm_val)
-  return hexstr[2:]
+    """Get the hex representation of the imm value"""
+    if imm[0] == '-':
+        is_negative = 1
+        imm = imm[1:]
+    else:
+        is_negative = 0
+    imm_val = int(imm, 0)
+    if is_negative:
+        imm_val = -imm_val
+    hexstr = sint_to_hex(imm_val)
+    return hexstr[2:]

--- a/scripts/sail_log_to_trace_csv.py
+++ b/scripts/sail_log_to_trace_csv.py
@@ -27,69 +27,72 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 from riscv_trace_csv import *
 
 START_RE = re.compile(r"\[4\] \[M\]: 0x.*00001010")
-END_RE   = re.compile(r"ecall")
+END_RE = re.compile(r"ecall")
 INSTR_RE = re.compile(r"\[[0-9].*\] \[(?P<pri>.)\]: 0x(?P<addr>[A-F0-9]+?)"
-                       " \(0x(?P<bin>[A-F0-9]+?)\) (?P<instr>.+?$)")
-RD_RE    = re.compile(r"x(?P<reg>[0-9]+?) <- 0x(?P<val>[A-F0-9]*)")
+                      " \(0x(?P<bin>[A-F0-9]+?)\) (?P<instr>.+?$)")
+RD_RE = re.compile(r"x(?P<reg>[0-9]+?) <- 0x(?P<val>[A-F0-9]*)")
+
 
 def process_sail_sim_log(sail_log, csv):
-  """Process SAIL RISCV simulation log.
+    """Process SAIL RISCV simulation log.
 
-  Extract instruction and affected register information from sail simulation
-  log and save to a list.
-  """
-  logging.info("Processing sail log : %s" % sail_log)
-  instr_cnt = 0
+    Extract instruction and affected register information from sail simulation
+    log and save to a list.
+    """
+    logging.info("Processing sail log : {}".format(sail_log))
+    instr_cnt = 0
 
-  with open(sail_log, "r") as f, open(csv, "w") as csv_fd:
-    search_start = 0
-    instr_start = 0
-    trace_csv = RiscvInstructionTraceCsv(csv_fd)
-    trace_csv.start_new_trace()
-    instr = None
-    for line in f:
-      # Extract instruction infromation
-      m = START_RE.search(line)
-      if m:
-        search_start = 1
-        continue
-      m = END_RE.search(line)
-      if m:
-        break
-      if search_start:
-        instr = INSTR_RE.search(line)
-        if instr:
-          instr_start = 1
-          pri = instr.group("pri")
-          addr = instr.group("addr").lower()
-          binary = instr.group("bin").lower()
-          instr_str = instr.group("instr")
-          continue
-        if instr_start:
-          m = RD_RE.search(line)
-          if m:
-            # Write the extracted instruction to a csvcol buffer file
-            instr_cnt += 1
-            rv_instr_trace = RiscvInstructionTraceEntry()
-            rv_instr_trace.gpr.append(
-              gpr_to_abi("x%0s" % m.group("reg")) + ":" + m.group("val").lower())
-            rv_instr_trace.mode = pri
-            rv_instr_trace.pc = addr
-            rv_instr_trace.binary = binary
-            rv_instr_trace.instr_str = instr_str
-            trace_csv.write_trace_entry(rv_instr_trace)
-            instr_start = 0
-  logging.info("Processed instruction count : %d" % instr_cnt)
+    with open(sail_log, "r") as f, open(csv, "w") as csv_fd:
+        search_start = 0
+        instr_start = 0
+        trace_csv = RiscvInstructionTraceCsv(csv_fd)
+        trace_csv.start_new_trace()
+        instr = None
+        for line in f:
+            # Extract instruction infromation
+            m = START_RE.search(line)
+            if m:
+                search_start = 1
+                continue
+            m = END_RE.search(line)
+            if m:
+                break
+            if search_start:
+                instr = INSTR_RE.search(line)
+                if instr:
+                    instr_start = 1
+                    pri = instr.group("pri")
+                    addr = instr.group("addr").lower()
+                    binary = instr.group("bin").lower()
+                    instr_str = instr.group("instr")
+                    continue
+                if instr_start:
+                    m = RD_RE.search(line)
+                    if m:
+                        # Write the extracted instruction to a csvcol buffer file
+                        instr_cnt += 1
+                        rv_instr_trace = RiscvInstructionTraceEntry()
+                        rv_instr_trace.gpr.append(
+                            gpr_to_abi("x{}".format(m.group("reg"))) + ":" + m.group(
+                                "val").lower())
+                        rv_instr_trace.mode = pri
+                        rv_instr_trace.pc = addr
+                        rv_instr_trace.binary = binary
+                        rv_instr_trace.instr_str = instr_str
+                        trace_csv.write_trace_entry(rv_instr_trace)
+                        instr_start = 0
+    logging.info("Processed instruction count : {}".format(instr_cnt))
 
 
 def main():
-  # Parse input arguments
-  parser = argparse.ArgumentParser()
-  parser.add_argument("--log", type=str, help="Input sail simulation log")
-  parser.add_argument("--csv", type=str, help="Output trace csv_buf file")
-  args = parser.parse_args()
-  # Process sail log
-  process_sail_sim_log(args.log, args.csv)
+    # Parse input arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log", type=str, help="Input sail simulation log")
+    parser.add_argument("--csv", type=str, help="Output trace csv_buf file")
+    args = parser.parse_args()
+    # Process sail log
+    process_sail_sim_log(args.log, args.csv)
+
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/scripts/spike_log_to_trace_csv.py
+++ b/scripts/spike_log_to_trace_csv.py
@@ -27,209 +27,212 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 from riscv_trace_csv import *
 from lib import *
 
-RD_RE    = re.compile(r"(?P<pri>\d) 0x(?P<addr>[a-f0-9]+?) " \
-                      "\((?P<bin>.*?)\) (?P<reg>[xf]\s*\d*?) 0x(?P<val>[a-f0-9]+)")
-CORE_RE  = re.compile(r"core.*0x(?P<addr>[a-f0-9]+?) \(0x(?P<bin>.*?)\) (?P<instr>.*?)$")
-ILLE_RE  = re.compile(r"trap_illegal_instruction")
+RD_RE = re.compile(r"(?P<pri>\d) 0x(?P<addr>[a-f0-9]+?) " \
+                   "\((?P<bin>.*?)\) (?P<reg>[xf]\s*\d*?) 0x(?P<val>[a-f0-9]+)")
+CORE_RE = re.compile(
+    r"core.*0x(?P<addr>[a-f0-9]+?) \(0x(?P<bin>.*?)\) (?P<instr>.*?)$")
+ILLE_RE = re.compile(r"trap_illegal_instruction")
 
 LOGGER = logging.getLogger()
 
 
 def process_instr(trace):
-  if trace.instr == "jal":
-    # Spike jal format jal rd, -0xf -> jal rd, -15
-    idx = trace.operand.rfind(",")
-    imm = trace.operand[idx+1:]
-    if imm[0] == "-":
-      imm = "-" + str(int(imm[1:], 16))
-    else:
-      imm = str(int(imm, 16))
-    trace.operand = trace.operand[0:idx+1] + imm
-  trace.operand = trace.operand.replace("(", ",")
-  trace.operand = trace.operand.replace(")", "")
+    if trace.instr == "jal":
+        # Spike jal format jal rd, -0xf -> jal rd, -15
+        idx = trace.operand.rfind(",")
+        imm = trace.operand[idx + 1:]
+        if imm[0] == "-":
+            imm = "-" + str(int(imm[1:], 16))
+        else:
+            imm = str(int(imm, 16))
+        trace.operand = trace.operand[0:idx + 1] + imm
+    trace.operand = trace.operand.replace("(", ",")
+    trace.operand = trace.operand.replace(")", "")
 
 
 def read_spike_instr(match, full_trace):
-  '''Unpack a regex match for CORE_RE to a RiscvInstructionTraceEntry
+    """Unpack a regex match for CORE_RE to a RiscvInstructionTraceEntry
 
-  If full_trace is true, extract operand data from the disassembled
-  instruction.
+    If full_trace is true, extract operand data from the disassembled
+    instruction.
 
-  '''
+    """
 
-  # Extract the disassembled instruction.
-  disasm = match.group('instr')
+    # Extract the disassembled instruction.
+    disasm = match.group('instr')
 
-  # Spike's disassembler shows a relative jump as something like "j pc +
-  # 0x123" or "j pc - 0x123". We just want the relative offset.
-  disasm = disasm.replace('pc + ', '').replace('pc - ', '-')
+    # Spike's disassembler shows a relative jump as something like "j pc +
+    # 0x123" or "j pc - 0x123". We just want the relative offset.
+    disasm = disasm.replace('pc + ', '').replace('pc - ', '-')
 
-  instr = RiscvInstructionTraceEntry()
-  instr.pc = match.group('addr')
-  instr.instr_str = disasm
-  instr.binary = match.group('bin')
+    instr = RiscvInstructionTraceEntry()
+    instr.pc = match.group('addr')
+    instr.instr_str = disasm
+    instr.binary = match.group('bin')
 
-  if full_trace:
-    opcode = disasm.split(' ')[0]
-    operand = disasm[len(opcode):].replace(' ', '')
-    instr.instr, instr.operand = \
-      convert_pseudo_instr(opcode, operand, instr.binary)
+    if full_trace:
+        opcode = disasm.split(' ')[0]
+        operand = disasm[len(opcode):].replace(' ', '')
+        instr.instr, instr.operand = \
+            convert_pseudo_instr(opcode, operand, instr.binary)
 
-    process_instr(instr)
+        process_instr(instr)
 
-  return instr
+    return instr
 
 
 def read_spike_trace(path, full_trace):
-  '''Read a Spike simulation log at <path>, yielding executed instructions.
+    """Read a Spike simulation log at <path>, yielding executed instructions.
 
-  This assumes that the log was generated with the -l and --log-commits options
-  to Spike.
+    This assumes that the log was generated with the -l and --log-commits options
+    to Spike.
 
-  If full_trace is true, extract operands from the disassembled instructions.
+    If full_trace is true, extract operands from the disassembled instructions.
 
-  Since Spike has a strange trampoline that always runs at the start, we skip
-  instructions up to and including the one at PC 0x1010 (the end of the
-  trampoline). At the end of a DV program, there's an ECALL instruction, which
-  we take as a signal to stop checking, so we ditch everything that follows
-  that instruction.
+    Since Spike has a strange trampoline that always runs at the start, we skip
+    instructions up to and including the one at PC 0x1010 (the end of the
+    trampoline). At the end of a DV program, there's an ECALL instruction, which
+    we take as a signal to stop checking, so we ditch everything that follows
+    that instruction.
 
-  This function yields instructions as it parses them as tuples of the form
-  (entry, illegal). entry is a RiscvInstructionTraceEntry. illegal is a
-  boolean, which is true if the instruction caused an illegal instruction trap.
+    This function yields instructions as it parses them as tuples of the form
+    (entry, illegal). entry is a RiscvInstructionTraceEntry. illegal is a
+    boolean, which is true if the instruction caused an illegal instruction trap.
 
-  '''
+    """
 
-  # This loop is a simple FSM with states TRAMPOLINE, INSTR, EFFECT. The idea
-  # is that we're in state TRAMPOLINE until we get to the end of Spike's
-  # trampoline, then we switch between INSTR (where we expect to read an
-  # instruction) and EFFECT (where we expect to read commit information).
-  #
-  # We yield a RiscvInstructionTraceEntry object each time we leave EFFECT
-  # (going back to INSTR), we loop back from INSTR to itself, or we get to the
-  # end of the file and have an instruction in hand.
-  #
-  # On entry to the loop body, we are in state TRAMPOLINE if in_trampoline is
-  # true. Otherwise, we are in state EFFECT if instr is not None, otherwise we
-  # are in state INSTR.
+    # This loop is a simple FSM with states TRAMPOLINE, INSTR, EFFECT. The idea
+    # is that we're in state TRAMPOLINE until we get to the end of Spike's
+    # trampoline, then we switch between INSTR (where we expect to read an
+    # instruction) and EFFECT (where we expect to read commit information).
+    #
+    # We yield a RiscvInstructionTraceEntry object each time we leave EFFECT
+    # (going back to INSTR), we loop back from INSTR to itself, or we get to the
+    # end of the file and have an instruction in hand.
+    #
+    # On entry to the loop body, we are in state TRAMPOLINE if in_trampoline is
+    # true. Otherwise, we are in state EFFECT if instr is not None, otherwise we
+    # are in state INSTR.
 
-  end_trampoline_re = re.compile(r'core.*: 0x0*1010 ')
+    end_trampoline_re = re.compile(r'core.*: 0x0*1010 ')
 
-  in_trampoline = True
-  instr = None
+    in_trampoline = True
+    instr = None
 
-  with open(path, 'r') as handle:
-    for line in handle:
-      if in_trampoline:
-        # The TRAMPOLINE state
-        if end_trampoline_re.match(line):
-          in_trampoline = False
-        continue
+    with open(path, 'r') as handle:
+        for line in handle:
+            if in_trampoline:
+                # The TRAMPOLINE state
+                if end_trampoline_re.match(line):
+                    in_trampoline = False
+                continue
 
-      if instr is None:
-        # The INSTR state. We expect to see a line matching CORE_RE. We'll
-        # discard any other lines.
-        instr_match = CORE_RE.match(line)
-        if not instr_match:
-          continue
+            if instr is None:
+                # The INSTR state. We expect to see a line matching CORE_RE.
+                # We'll discard any other lines.
+                instr_match = CORE_RE.match(line)
+                if not instr_match:
+                    continue
 
-        instr = read_spike_instr(instr_match, full_trace)
+                instr = read_spike_instr(instr_match, full_trace)
 
-        # If instr.instr_str is 'ecall', we should stop.
-        if instr.instr_str == 'ecall':
-          break
+                # If instr.instr_str is 'ecall', we should stop.
+                if instr.instr_str == 'ecall':
+                    break
 
-        continue
+                continue
 
-      # The EFFECT state. If the line matches CORE_RE, we should have been in
-      # state INSTR, so we yield the instruction we had, read the new
-      # instruction and continue. As above, if the new instruction is 'ecall',
-      # we need to stop immediately.
-      instr_match = CORE_RE.match(line)
-      if instr_match:
-        yield (instr, False)
-        instr = read_spike_instr(instr_match, full_trace)
-        if instr.instr_str == 'ecall':
-          break
-        continue
+            # The EFFECT state. If the line matches CORE_RE, we should have been in
+            # state INSTR, so we yield the instruction we had, read the new
+            # instruction and continue. As above, if the new instruction is 'ecall',
+            # we need to stop immediately.
+            instr_match = CORE_RE.match(line)
+            if instr_match:
+                yield instr, False
+                instr = read_spike_instr(instr_match, full_trace)
+                if instr.instr_str == 'ecall':
+                    break
+                continue
 
-      # The line doesn't match CORE_RE, so we are definitely on a follow-on
-      # line in the log. First, check for illegal instructions
-      if 'trap_illegal_instruction' in line:
-        yield (instr, True)
-        instr = None
-        continue
+            # The line doesn't match CORE_RE, so we are definitely on a follow-on
+            # line in the log. First, check for illegal instructions
+            if 'trap_illegal_instruction' in line:
+                yield (instr, True)
+                instr = None
+                continue
 
-      # The instruction seems to have been fine. Do we have commit data (from
-      # the --log-commits Spike option)?
-      commit_match = RD_RE.match(line)
-      if commit_match:
-        instr.gpr.append(gpr_to_abi(commit_match.group('reg')
-                                    .replace(' ', '')) +
-                         ':' + commit_match.group('val'))
-        instr.mode = commit_match.group('pri')
+            # The instruction seems to have been fine. Do we have commit data (from
+            # the --log-commits Spike option)?
+            commit_match = RD_RE.match(line)
+            if commit_match:
+                instr.gpr.append(gpr_to_abi(commit_match.group('reg')
+                                            .replace(' ', '')) +
+                                 ':' + commit_match.group('val'))
+                instr.mode = commit_match.group('pri')
 
-    # At EOF, we might have an instruction in hand. Yield it if so.
-    if instr is not None:
-      yield (instr, False)
+        # At EOF, we might have an instruction in hand. Yield it if so.
+        if instr is not None:
+            yield (instr, False)
 
 
-def process_spike_sim_log(spike_log, csv, full_trace = 0):
-  """Process SPIKE simulation log.
+def process_spike_sim_log(spike_log, csv, full_trace=0):
+    """Process SPIKE simulation log.
 
-  Extract instruction and affected register information from spike simulation
-  log and write the results to a CSV file at csv. Returns the number of
-  instructions written.
+    Extract instruction and affected register information from spike simulation
+    log and write the results to a CSV file at csv. Returns the number of
+    instructions written.
 
-  """
-  logging.info("Processing spike log : %s" % spike_log)
-  instrs_in = 0
-  instrs_out = 0
+    """
+    logging.info("Processing spike log : {}".format(spike_log))
+    instrs_in = 0
+    instrs_out = 0
 
-  with open(csv, "w") as csv_fd:
-    trace_csv = RiscvInstructionTraceCsv(csv_fd)
-    trace_csv.start_new_trace()
+    with open(csv, "w") as csv_fd:
+        trace_csv = RiscvInstructionTraceCsv(csv_fd)
+        trace_csv.start_new_trace()
 
-    for (entry, illegal) in read_spike_trace(spike_log, full_trace):
-      instrs_in += 1
+        for (entry, illegal) in read_spike_trace(spike_log, full_trace):
+            instrs_in += 1
 
-      if illegal and full_trace:
-        logging.debug("Illegal instruction: {}, opcode:{}"
-                      .format(entry.instr_str, entry.binary))
+            if illegal and full_trace:
+                logging.debug("Illegal instruction: {}, opcode:{}"
+                              .format(entry.instr_str, entry.binary))
 
-      # Instructions that cause no architectural update (which includes illegal
-      # instructions) are ignored if full_trace is false.
-      #
-      # We say that an instruction caused an architectural update if either we
-      # saw a commit line (in which case, entry.gpr will contain a single
-      # entry) or the instruction was 'wfi' or 'ecall'.
-      if not (full_trace or entry.gpr or entry.instr_str in ['wfi', 'ecall']):
-        continue
+            # Instructions that cause no architectural update (which includes illegal
+            # instructions) are ignored if full_trace is false.
+            #
+            # We say that an instruction caused an architectural update if either we
+            # saw a commit line (in which case, entry.gpr will contain a single
+            # entry) or the instruction was 'wfi' or 'ecall'.
+            if not (full_trace or entry.gpr or entry.instr_str in ['wfi',
+                                                                   'ecall']):
+                continue
 
-      trace_csv.write_trace_entry(entry)
-      instrs_out += 1
+            trace_csv.write_trace_entry(entry)
+            instrs_out += 1
 
-  logging.info("Processed instruction count : %d" % instrs_in)
-  logging.info("CSV saved to : %s" % csv)
-  return instrs_out
+    logging.info("Processed instruction count : {}".format(instrs_in))
+    logging.info("CSV saved to : {}".format(csv))
+    return instrs_out
 
 
 def main():
-  # Parse input arguments
-  parser = argparse.ArgumentParser()
-  parser.add_argument("--log", type=str, help="Input spike simulation log")
-  parser.add_argument("--csv", type=str, help="Output trace csv_buf file")
-  parser.add_argument("-f", "--full_trace", dest="full_trace", action="store_true",
-                                         help="Generate the full trace")
-  parser.add_argument("-v", "--verbose", dest="verbose", action="store_true",
-                                         help="Verbose logging")
-  parser.set_defaults(full_trace=False)
-  parser.set_defaults(verbose=False)
-  args = parser.parse_args()
-  setup_logging(args.verbose)
-  # Process spike log
-  process_spike_sim_log(args.log, args.csv, args.full_trace)
+    # Parse input arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log", type=str, help="Input spike simulation log")
+    parser.add_argument("--csv", type=str, help="Output trace csv_buf file")
+    parser.add_argument("-f", "--full_trace", dest="full_trace",
+                        action="store_true",
+                        help="Generate the full trace")
+    parser.add_argument("-v", "--verbose", dest="verbose", action="store_true",
+                        help="Verbose logging")
+    parser.set_defaults(full_trace=False)
+    parser.set_defaults(verbose=False)
+    args = parser.parse_args()
+    setup_logging(args.verbose)
+    # Process spike log
+    process_spike_sim_log(args.log, args.csv, args.full_trace)
 
 
 if __name__ == "__main__":
-  main()
+    main()


### PR DESCRIPTION
This PR converts the python codes in riscv-dv repo to be PEP8 compliant (PR also contains other minor fixes).