### PR TITLE
Fix invalid CSR test for RV64GCV target

### DIFF
--- a/target/rv64gcv/testlist.yaml
+++ b/target/rv64gcv/testlist.yaml
@@ -29,7 +29,80 @@
 # gcc_opts        : gcc compile options
 # --------------------------------------------------------------------------------
 
-- import: <riscv_dv_root>/target/rv64gc/testlist.yaml
+- import: <riscv_dv_root>/target/rv64imc/testlist.yaml
+
+- test: riscv_invalid_csr_test
+  description: >
+    Boot core into random privileged mode and generate csr accesses to invalid CSRs (at a higher priv mode)
+  iterations: 2
+  gen_test: riscv_rand_instr_test
+  gen_opts: >
+    +instr_cnt=6000
+    +num_of_sub_program=0
+    +enable_access_invalid_csr_level=1
+  rtl_test: core_invalid_csr_test
+  sim_opts: >
+    +require_signature_addr=1
+
+- test: riscv_amo_test
+  description: >
+    RISC-V atomic instruction extension test
+  iterations: 2
+  gen_test: riscv_rand_instr_test
+  gen_opts: >
+    +instr_cnt=5000
+    +num_of_sub_program=5
+    +directed_instr_0=riscv_lr_sc_instr_stream,10
+    +directed_instr_1=riscv_amo_instr_stream,10
+  rtl_test: core_base_test
+
+- test: riscv_floating_point_arithmetic_test
+  description: >
+    Enable floating point instructions
+  gen_opts: >
+    +instr_cnt=10000
+    +num_of_sub_program=0
+    +no_fence=1
+    +no_data_page=1
+    +no_branch_jump=1
+    +enable_floating_point=1
+    +boot_mode=m
+  iterations: 1
+  gen_test: riscv_instr_base_test
+  rtl_test: core_base_test
+
+- test: riscv_floating_point_rand_test
+  description: >
+    Enable floating point instructions
+  gen_opts: >
+    +enable_floating_point=1
+    +instr_cnt=10000
+    +num_of_sub_program=5
+    +directed_instr_0=riscv_load_store_rand_instr_stream,4
+    +directed_instr_1=riscv_loop_instr,4
+    +directed_instr_2=riscv_multi_page_load_store_instr_stream,4
+    +directed_instr_3=riscv_mem_region_stress_test,4
+    +directed_instr_4=riscv_jal_instr,4
+  iterations: 1
+  gen_test: riscv_instr_base_test
+  rtl_test: core_base_test
+
+- test: riscv_floating_point_mmu_stress_test
+  description: >
+    Test with different patterns of load/store instructions, stress test MMU
+    operations.
+  iterations: 2
+  gen_test: riscv_instr_base_test
+  gen_opts: >
+    +instr_cnt=5000
+    +num_of_sub_program=5
+    +enable_floating_point=1
+    +directed_instr_0=riscv_load_store_rand_instr_stream,40
+    +directed_instr_1=riscv_load_store_hazard_instr_stream,40
+    +directed_instr_2=riscv_multi_page_load_store_instr_stream,10
+    +directed_instr_3=riscv_mem_region_stress_test,10
+  rtl_test: core_base_test
+
 
 - test: riscv_vector_arithmetic_test
   description: >


### PR DESCRIPTION
Update testlist to excluding all non machine mode test for RV64GCV target. Only machine mode is enabled for this target currently.

Fix #700 