### PR TITLE
debug_rom_gen: Fix return address issue

### DIFF
--- a/src/riscv_debug_rom_gen.sv
+++ b/src/riscv_debug_rom_gen.sv
@@ -93,9 +93,11 @@ class riscv_debug_rom_gen extends riscv_asm_program_gen;
                     cfg.num_debug_sub_program);
       main_program[hart].post_process_instr();
       main_program[hart].generate_instr_stream(.no_label(1'b1));
-      debug_main = {debug_main, main_program[hart].instr_string_list};
-      // Jump to debug_end section (before the debug sub-routines)
-      debug_main = {debug_main, $sformatf("%sj debug_end", indent)};
+      debug_main = {debug_main,
+                    main_program[hart].instr_string_list,
+                    $sformatf("%sla x%0d, debug_end", indent, cfg.scratch_reg),
+                    $sformatf("%sjalr x0, x%0d, 0", indent, cfg.scratch_reg)
+                   };
       insert_sub_program(sub_program[hart], debug_main);
       gen_section($sformatf("%0sdebug_rom", hart_prefix(hart)), debug_main);
       if (cfg.enable_ebreak_in_debug_rom) begin

--- a/src/riscv_debug_rom_gen.sv
+++ b/src/riscv_debug_rom_gen.sv
@@ -93,8 +93,10 @@ class riscv_debug_rom_gen extends riscv_asm_program_gen;
                     cfg.num_debug_sub_program);
       main_program[hart].post_process_instr();
       main_program[hart].generate_instr_stream(.no_label(1'b1));
-      insert_sub_program(sub_program[hart], debug_main);
       debug_main = {debug_main, main_program[hart].instr_string_list};
+      // Jump to debug_end section (before the debug sub-routines)
+      debug_main = {debug_main, $sformatf("%sj debug_end", indent)};
+      insert_sub_program(sub_program[hart], debug_main);
       gen_section($sformatf("%0sdebug_rom", hart_prefix(hart)), debug_main);
       if (cfg.enable_ebreak_in_debug_rom) begin
         gen_ebreak_footer();


### PR DESCRIPTION
The debug ROM is assembled with the sub-routines directly below the main
code section. The program is thus able to run straight through into the
sub-routine without there ever being a jalr into that sub-routine. That
means the return address for the sub-routine is undefined, and the
program jumps to a bogus address when the sub-routine returns.

This fix forces the main debug program to end (by jumping to debug_end)
and not just run on into the sub-routines, similarly to how the main
(non-debug) program works.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>