### PR TITLE
coverage flow updates

### DIFF
--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -427,4 +427,169 @@ def convert_pseudo_instr(instr_name, operands, binary):
         else:
             instr_name = "jalr"
             operands = "zero,ra,0"
+    # RV32B pseudo instructions
+    # TODO: support "rev", "orc", and "zip/unzip" instructions for RV64
+    elif instr_name == "rev.p":
+        instr_name = "grevi"
+        operands += ",1"
+    elif instr_name == "rev2.n":
+        instr_name = "grevi"
+        operands += ",2"
+    elif instr_name == "rev.n":
+        instr_name = "grevi"
+        operands += ",3"
+    elif instr_name == "rev4.b":
+        instr_name = "grevi"
+        operands += ",4"
+    elif instr_name == "rev2.b":
+        instr_name = "grevi"
+        operands += ",6"
+    elif instr_name == "rev.b":
+        instr_name = "grevi"
+        operands += ",7"
+    elif instr_name == "rev8.h":
+        instr_name = "grevi"
+        operands += ",8"
+    elif instr_name == "rev4.h":
+        instr_name = "grevi"
+        operands += ",12"
+    elif instr_name == "rev2.h":
+        instr_name = "grevi"
+        operands += ",14"
+    elif instr_name == "rev.h":
+        instr_name = "grevi"
+        operands += ",15"
+    elif instr_name == "rev16":
+        instr_name = "grevi"
+        operands += ",16"
+    elif instr_name == "rev8":
+        instr_name = "grevi"
+        operands += ",24"
+    elif instr_name == "rev4":
+        instr_name = "grevi"
+        operands += ",28"
+    elif instr_name == "rev2":
+        instr_name = "grevi"
+        operands += ",30"
+    elif instr_name == "rev":
+        instr_name = "grevi"
+        operands += ",31"
+    elif instr_name == "orc.p":
+        instr_name = "gorci"
+        operands += ",1"
+    elif instr_name == "orc2.n":
+        instr_name = "gorci"
+        operands += ",2"
+    elif instr_name == "orc.n":
+        instr_name = "gorci"
+        operands += ",3"
+    elif instr_name == "orc4.b":
+        instr_name = "gorci"
+        operands += ",4"
+    elif instr_name == "orc2.b":
+        instr_name = "gorci"
+        operands += ",6"
+    elif instr_name == "orc.b":
+        instr_name = "gorci"
+        operands += ",7"
+    elif instr_name == "orc8.h":
+        instr_name = "gorci"
+        operands += ",8"
+    elif instr_name == "orc4.h":
+        instr_name = "gorci"
+        operands += ",12"
+    elif instr_name == "orc2.h":
+        instr_name = "gorci"
+        operands += ",14"
+    elif instr_name == "orc.h":
+        instr_name = "gorci"
+        operands += ",15"
+    elif instr_name == "orc16":
+        instr_name = "gorci"
+        operands += ",16"
+    elif instr_name == "orc8":
+        instr_name = "gorci"
+        operands += ",24"
+    elif instr_name == "orc4":
+        instr_name = "gorci"
+        operands += ",28"
+    elif instr_name == "orc2":
+        instr_name = "gorci"
+        operands += ",30"
+    elif instr_name == "orc":
+        instr_name = "gorci"
+        operands += ",31"
+    elif instr_name == "zext.b":
+        instr_name = "andi"
+        operands += ",255"
+    elif instr_name == "zext.h":
+        # TODO: support for RV64B
+        instr_name = "pack"
+        operands += ",zero"
+    elif instr_name == "zext.w":
+        instr_name = "pack"
+        operands += ",zero"
+    elif instr_name == "sext.w":
+        instr_name = "addiw"
+        operands += ",0"
+    elif instr_name == "zip.n":
+        instr_name = "shfli"
+        operands += ",1"
+    elif instr_name == "unzip.n":
+        instr_name = "unshfli"
+        operands += ",1"
+    elif instr_name == "zip2.b":
+        instr_name = "shfli"
+        operands += ",2"
+    elif instr_name == "unzip2.b":
+        instr_name = "unshfli"
+        operands += ",2"
+    elif instr_name == "zip.b":
+        instr_name = "shfli"
+        operands += ",3"
+    elif instr_name == "unzip.b":
+        instr_name = "unshfli"
+        operands += ",3"
+    elif instr_name == "zip4.h":
+        instr_name = "shfli"
+        operands += ",4"
+    elif instr_name == "unzip4.h":
+        instr_name = "unshfli"
+        operands += ",4"
+    elif instr_name == "zip2.h":
+        instr_name = "shfli"
+        operands += ",6"
+    elif instr_name == "unzip2.h":
+        instr_name = "unshfli"
+        operands += ",6"
+    elif instr_name == "zip.h":
+        instr_name = "shfli"
+        operands += ",7"
+    elif instr_name == "unzip.h":
+        instr_name = "unshfli"
+        operands += ",7"
+    elif instr_name == "zip8":
+        instr_name = "shfli"
+        operands += ",8"
+    elif instr_name == "unzip8":
+        instr_name = "unshfli"
+        operands += ",8"
+    elif instr_name == "zip4":
+        instr_name = "shfli"
+        operands += ",12"
+    elif instr_name == "unzip4":
+        instr_name = "unshfli"
+        operands += ",12"
+    elif instr_name == "zip2":
+        instr_name = "shfli"
+        operands += ",14"
+    elif instr_name == "unzip2":
+        instr_name = "unshfli"
+        operands += ",14"
+    elif instr_name == "zip":
+        instr_name = "shfli"
+        operands += ",15"
+    elif instr_name == "unzip":
+        instr_name = "unshfli"
+        operands += ",15"
     return instr_name, operands

--- a/scripts/ovpsim_log_to_trace_csv.py
+++ b/scripts/ovpsim_log_to_trace_csv.py
@@ -128,8 +128,12 @@ def process_trace(trace):
         process_jalr(trace)
     trace.instr, trace.operand = convert_pseudo_instr(
         trace.instr, trace.operand, trace.binary)
-    trace.operand = trace.operand.replace(")", "")
-    trace.operand = trace.operand.replace("(", ",")
+    # process any instruction of the form:
+    # <instr> <reg> <imm>(<reg>)
+    m = BASE_RE.search(trace.operand)
+    if m:
+        trace.operand = "{},{},{}".format(
+            m.group("rd"), m.group("rs1"), m.group("imm"))
 
 
 def process_imm(trace):

--- a/src/isa/riscv_instr_cov.svh
+++ b/src/isa/riscv_instr_cov.svh
@@ -268,10 +268,10 @@
       I_FORMAT: begin
         `DV_CHECK_FATAL(operands.size() == 3, instr_name)
         if(category == LOAD) begin
-          // load rd, imm(rs1)
-          rs1 = get_gpr(operands[2]);
-          rs1_value = get_gpr_state(operands[2]);
-          get_val(operands[1], imm);
+          // load rd, imm(rs1) -> rd,rs1,imm
+          rs1 = get_gpr(operands[1]);
+          rs1_value = get_gpr_state(operands[1]);
+          get_val(operands[2], imm);
         end else if(category == CSR) begin
           // csrrwi rd, csr, imm
           get_val(operands[2], imm);
@@ -290,11 +290,12 @@
       S_FORMAT, B_FORMAT: begin
         `DV_CHECK_FATAL(operands.size() == 3)
         if(category == STORE) begin
-          rs2 = get_gpr(operands[0]);
-          rs2_value = get_gpr_state(operands[0]);
-          rs1 = get_gpr(operands[2]);
-          rs1_value = get_gpr_state(operands[2]);
-          get_val(operands[1], imm);
+          // store rs2, imm(rs1) -> rs1,rs2,imm
+          rs2 = get_gpr(operands[1]);
+          rs2_value = get_gpr_state(operands[1]);
+          rs1 = get_gpr(operands[0]);
+          rs1_value = get_gpr_state(operands[0]);
+          get_val(operands[2], imm);
         end else begin
           // bne rs1, rs2, imm
           rs1 = get_gpr(operands[0]);
@@ -358,18 +359,18 @@
         end
       end
       CL_FORMAT: begin
-        // c.lw rd, imm(rs1)
-        get_val(operands[1], imm);
-        rs1 = get_gpr(operands[2]);
-        rs1_value = get_gpr_state(operands[2]);
+        // c.lw rd, imm(rs1) -> rd,rs1,imm
+        get_val(operands[2], imm);
+        rs1 = get_gpr(operands[1]);
+        rs1_value = get_gpr_state(operands[1]);
       end
       CS_FORMAT: begin
-        // c.sw rs2,imm(rs1)
-        rs2 = get_gpr(operands[0]);
-        rs2_value = get_gpr_state(operands[0]);
-        rs1 = get_gpr(operands[2]);
-        rs1_value = get_gpr_state(operands[2]);
-        get_val(operands[1], imm);
+        // c.sw rs2,imm(rs1) -> rs1,rs2,imm
+        rs2 = get_gpr(operands[1]);
+        rs2_value = get_gpr_state(operands[1]);
+        rs1 = get_gpr(operands[0]);
+        rs1_value = get_gpr_state(operands[0]);
+        get_val(operands[2], imm);
       end
       CA_FORMAT: begin
         // c.and rd, rs2 (rs1 == rd)


### PR DESCRIPTION
This PR does 2 main things to the functional coverage flow
1) Allows the .csv conversion scripts to recognize bit-manipulation pseudo-instructions - currently none are recognized so coverage failures are fairly common.
2) Changes how the 'operand' field of the output CSV is formatted.
Currently for any instructions that have an address (e.g. `rd, rs1(imm)`), the operands are structured as `rd,imm,rs1` in the output CSV file. This doesn't align with how the spec structures operands for these sorts of instructions, so this patch rearranges the operands such that they are displayed as `rd,rs1,imm` in the output CSV.
This has the side effect of standardizing how the CSVs are parsed among Spike, OVPsim, and any cores using riscv-dv (like Ibex).