### PR TITLE
Pass -fno-extended-identifiers to VCS

### DIFF
--- a/yaml/simulator.yaml
+++ b/yaml/simulator.yaml
@@ -21,6 +21,7 @@
              -f <cwd>/files.f -full64
              -l <out>/compile.log
              -LDFLAGS '-Wl,--no-as-needed'
+             -CFLAGS '--std=c99 -fno-extended-identifiers'
              -Mdir=<out>/vcs_simv.csrc
              -o <out>/vcs_simv <cmp_opts> <cov_opts> "
     cov_opts: >


### PR DESCRIPTION
For some bizarre reason, VCS includes DPI code that has smart
quotes (yes, smart quotes) around some #error macros. Recent GCC
versions (g++ >= 10.2) have got proper support for UTF-8, which is
nice but makes them choke on these input files.

Passing -fno-extended-identifiers tells GCC to pretend that everything
is ASCII, and all is well again!