### PR TITLE
Add support for new Spike trace format

### DIFF
--- a/scripts/spike_log_to_trace_csv.py
+++ b/scripts/spike_log_to_trace_csv.py
@@ -27,10 +27,10 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 from riscv_trace_csv import *
 from lib import *
 
-RD_RE = re.compile(r"(?P<pri>\d) 0x(?P<addr>[a-f0-9]+?) " \
+RD_RE = re.compile(r"(core\s+\d+:\s+)?(?P<pri>\d) 0x(?P<addr>[a-f0-9]+?) " \
                    "\((?P<bin>.*?)\) (?P<reg>[xf]\s*\d*?) 0x(?P<val>[a-f0-9]+)")
 CORE_RE = re.compile(
-    r"core.*0x(?P<addr>[a-f0-9]+?) \(0x(?P<bin>.*?)\) (?P<instr>.*?)$")
+    r"core\s+\d+:\s+0x(?P<addr>[a-f0-9]+?) \(0x(?P<bin>.*?)\) (?P<instr>.*?)$")
 ADDR_RE = re.compile(
     r"(?P<rd>[a-z0-9]+?),(?P<imm>[\-0-9]+?)\((?P<rs1>[a-z0-9]+)\)")
 ILLE_RE = re.compile(r"trap_illegal_instruction")


### PR DESCRIPTION
Spike recently changed their log format, adding "`core 0:`" to some lines where it wasn't before. This broke the log-to-csv conversion script (see #742).

I have tested this with a small number of programs and the output CSV is now identical with both the old and new trace formats.

**However** I'm still working towards getting riscv-dv set up for the first time, so I may not have seen some of the more-exotic trace contents. I'd appreciate someone taking a careful look at my changes. In particular, should the `core 0:` phrase be added to any of the other regular expressions?