### PR TITLE
[questa] Remove -access=rwc from vlog command line arguments

### DIFF
--- a/yaml/simulator.yaml
+++ b/yaml/simulator.yaml
@@ -57,7 +57,6 @@
       - "vlog -64
         +incdir+<setting>
         +incdir+<user_extension>
-        -access=rwc
         -f <cwd>/files.f
         -sv
         -mfcu -cuname design_cuname


### PR DESCRIPTION
This doesn't seem to be supported by at least Questa 2020.03 (see
issue #780). I don't have a Questa licence or manual locally, but it
looks like this is an Xcelium flag. Maybe it was supported by other
Questa versions as a compatibility shim? If we need to allow the
equivalent access, I think the argument is "+acc", but I'm not
convinced it's needed at all, so suggest removing it entirely.

Fixes #780.