### PR TITLE
Update scripts for Metrics CI regression

### DIFF
--- a/.github/workflows/metrics-regress.yml
+++ b/.github/workflows/metrics-regress.yml
@@ -7,8 +7,8 @@ name: metrics-regress
 on:
   push:
     branches: [ master ]
-  #pull_request:
-  #  branches: [ master ]
+#  pull_request_target:
+#    branches: [ master ]
 
 # If you fork this repository, you must create a new Metrics project for your fork
 # and set the environment variable $METRICS_PROJECT_ID accordingly
@@ -22,5 +22,6 @@ jobs:
           METRICS_CI_TOKEN: ${{ secrets.METRICS_CI_TOKEN }}
           METRICS_REGRESSION_NAME: riscv-dv_regression
           METRICS_PROJECT_ID: ${{ secrets.METRICS_PROJECT_ID }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         shell: bash
 

--- a/.metrics.json
+++ b/.metrics.json
@@ -1,15 +1,8 @@
 {
-    "variables": {
-        "DSIM" : "${DSIM_HOME}/bin/dsim",
-        "DSIM_LIB_PATH" : "${DSIM_HOME}/uvm-1.2/src/dpi",
-        "RISCV_GCC" : "${RISCV_TOOLCHAIN}/bin/riscv-none-embed-gcc",
-        "RISCV_OBJCOPY" : "${RISCV_TOOLCHAIN}/bin/riscv-none-embed-objcopy",
-        "OVPSIM_PATH" : "/customer-tools/riscv-ovpsim/bin/Linux64"
-    },
     "builds": {
       "list": [{
         "name": "rv32imc",
-        "image": "ibex-dsim-toolchain:latest",
+        "image": "ibex-toolchain:v2",
         "memory" : "1",  
         "cmd": "python3 run.py --test riscv_arithmetic_basic_test --simulator dsim --output out --verbose --co",
         "wavesCmd": "python3 run.py --test riscv_arithmetic_basic_test --simulator dsim --output out --verbose --co"
@@ -27,8 +20,8 @@
                   "name": "riscv_arithmetic_basic_test",
                   "build": "rv32imc",
                   "iterations": 2,
-                  "cmd": "cd /mux-flow/results; python3 <rootDir>/run.py --test riscv_arithmetic_basic_test --seed <seed> --simulator dsim --iss ovpsim --so --out <rootDir>/out --verbose; <rootDir>/scripts/check-status $?; rm -fr <rootDir>/out/dsim",
-                  "wavesCmd": "python3 <rootDir>/run.py --test riscv_arithmetic_basic_test --seed <seed> --simulator dsim --iss ovpsim --so --out <rootDir>/out --verbose; <rootDir>/scripts/check-status $?; rm -rf out/dsim",
+                  "cmd": "cd /mux-flow/results; python3 <rootDir>/run.py --test riscv_arithmetic_basic_test --seed <seed> --simulator dsim --iss spike --so --out <rootDir>/out --verbose; <rootDir>/scripts/check-status $?; rm -fr <rootDir>/out/dsim",
+                  "wavesCmd": "python3 <rootDir>/run.py --test riscv_arithmetic_basic_test --seed <seed> --simulator dsim --iss spike --so --out <rootDir>/out --verbose; <rootDir>/scripts/check-status $?; rm -rf out/dsim",
                   "logFile": "simulation.log",
                   "metricsFile": "metrics.db",
                   "isPass": "Test passed",

--- a/scripts/genMetricsList.py
+++ b/scripts/genMetricsList.py
@@ -20,7 +20,7 @@
 
 import json
 
-runCmdBase = "cd /mux-flow/results; python3 <rootDir>/run.py --test TESTNAME --simulator dsim --iss ovpsim --seed <seed> --so --out <rootDir>/out --verbose; <rootDir>/scripts/check-status $?; rm -fr <rootDir>/out/dsim"
+runCmdBase = "cd /mux-flow/results; python3 <rootDir>/run.py --test TESTNAME --simulator dsim --iss spike --seed <seed> --so --out <rootDir>/out --verbose; <rootDir>/scripts/check-status $?; rm -fr <rootDir>/out/dsim"
 
 ## Based on testlist located in <rootDir>/yaml/base_testlist.yaml
 base_testList = ["riscv_arithmetic_basic_test",

--- a/yaml/iss.yaml
+++ b/yaml/iss.yaml
@@ -20,7 +20,7 @@
 - iss: ovpsim
   path_var: OVPSIM_PATH
   cmd: >
-    <path_var>/riscvOVPsim.exe
+    <path_var>/riscvOVPsimPlus.exe
     --controlfile <cfg_path>/riscvOVPsim.ic
     --objfilenoentry <elf>
     --override riscvOVPsim/cpu/simulateexceptions=T


### PR DESCRIPTION
metrics-regress.yml:
* Changes to work with pull requests. The `pull_request_target` event is able to access secret variables, however the event is still commented out while Metrics adds support for pulling the special branch created by a GitHub PR.

.metrics.json:
* Changes to use spike instead of OVPsim. The ibex-toolchain:v2 docker image contains spike as well as the lowRISC rv32imc toolchain.

genMetricsList.py:
* use spike instead of OVPsim

metrics-regress.py:
* Changes to work with pull requests. Create a git reference for the pull request branch and send this to Metrics.
* Fix lint errors
* Display complete message returned by Metrics API in case of error

iss.yml
* Change the name of the Imperas ISS executable. riscvOVPsimPlus is now required.
