### PR TITLE
Fixed wrong length of I, S, B-type immediates

### DIFF
--- a/pygen/pygen_src/isa/riscv_cov_instr.py
+++ b/pygen/pygen_src/isa/riscv_cov_instr.py
@@ -147,7 +147,7 @@ class riscv_cov_instr:
             if self.imm_type.name == "UIMM":
                 self.imm_len = 5
             else:
-                self.imm_len = 11
+                self.imm_len = 12
 
     def set_mode(self):
         # mode setting for Instruction Format

--- a/pygen/pygen_src/isa/riscv_instr.py
+++ b/pygen/pygen_src/isa/riscv_instr.py
@@ -316,7 +316,7 @@ class riscv_instr:
             if self.imm_type.name == "UIMM":
                 self.imm_len = 5
             else:
-                self.imm_len = 11
+                self.imm_len = 12
         self.imm_mask = (self.imm_mask << self.imm_len) & self.shift_t
 
     def extend_imm(self):

--- a/src/isa/riscv_instr.sv
+++ b/src/isa/riscv_instr.sv
@@ -344,7 +344,7 @@ class riscv_instr extends uvm_object;
       if(imm_type == UIMM) begin
         imm_len = 5;
       end else begin
-        imm_len = 11;
+        imm_len = 12;
       end
     end
     imm_mask = imm_mask << imm_len;


### PR DESCRIPTION
Previous setting caused sign extension of the second-last bit of the immediates for instructions such as JALR.

Signed-off-by: Henrik Fegran <Henrik.Fegran@silabs.com>