### PR TITLE
Issue #778 fix, change mie behavior in setup_mmode_reg

### DIFF
--- a/src/riscv_privileged_common_seq.sv
+++ b/src/riscv_privileged_common_seq.sv
@@ -89,7 +89,8 @@ class riscv_privileged_common_seq extends uvm_sequence;
     mstatus.set_field("SPP", 0);
     // Enable interrupt
     mstatus.set_field("MPIE", cfg.enable_interrupt);
-    mstatus.set_field("MIE", cfg.enable_interrupt);
+    // MIE is set when returning with mret, avoids trapping before returning
+    mstatus.set_field("MIE", 0);
     mstatus.set_field("SPIE", cfg.enable_interrupt);
     mstatus.set_field("SIE",  cfg.enable_interrupt);
     mstatus.set_field("UPIE", cfg.enable_interrupt);


### PR DESCRIPTION
MIE is explicitly set before mret is called, leading to potential infinite loop in case of an interrupt between interrupt enable and mret. Instead taken care of by MPIE as per Riscv-spec (Fix for issue #778 )

Signed-off-by: Henrik Fegran <Henrik.Fegran@silabs.com>