### PR TITLE
Improve status reporting

### DIFF
--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -157,7 +157,7 @@ def run_parallel_cmd(cmd_list, timeout_s=999, exit_on_error=0,
                               stderr=subprocess.STDOUT)
         children.append(ps)
     for i in range(len(children)):
-        logging.info("Command progress: {}/{}".format(i, len(children)))
+        logging.info("Command progress: {}/{}".format(i + 1, len(children)))
         logging.debug("Waiting for command: {}".format(cmd_list[i]))
         try:
             output = children[i].communicate(timeout=timeout_s)[0]


### PR DESCRIPTION
Report job progress like "1/2" and "2/2" instead of "0/2" and "1/2", as
it was done before.

Only a cosmetic change.