### PR TITLE
Fix broken run.py script

### DIFF
--- a/run.py
+++ b/run.py
@@ -304,7 +304,7 @@ def do_simulate(sim_cmd, simulator, test_list, cwd, sim_opts, seed_gen,
                                   test['test'], i, log_suffix)) + \
                               (" --target=%s " % (target)) + \
                               (" --gen_test=%s " % (test['gen_test'])) + \
-                              (" --seed={}".format(rand_seed))
+                              (" --seed={} ".format(rand_seed))
                     else:
                         cmd = lsf_cmd + " " + sim_cmd.rstrip() + \
                               (" +UVM_TESTNAME={} ".format(test['gen_test'])) + \


### PR DESCRIPTION
Delimiter was missing following the seed argument that was added in
run.py a couple of commits back.