### PR TITLE
[epmp] Add support for mseccfg CSR

### DIFF
--- a/pygen/pygen_src/riscv_instr_pkg.py
+++ b/pygen/pygen_src/riscv_instr_pkg.py
@@ -905,6 +905,8 @@ class privileged_reg_t(IntEnum):
     MCAUSE = 0x342  # Machine trap cause
     MTVAL = 0x343  # Machine bad address or instruction
     MIP = 0x344  # Machine interrupt pending
+    MSECCFG = 0x747 # Machine security configuration
+    MSECCFGH = 0x757 # Machine security configuration, RV32 only
     PMPCFG0 = 0x3A0  # Physical memory protection configuration
     PMPCFG1 = 0x3A1  # Physical memory protection configuration, RV32 only
     PMPCFG2 = 0x3A2  # Physical memory protection configuration
@@ -1174,6 +1176,13 @@ class store_lsu_hazard_e(IntEnum):
 class jalr_riscv_reg_t(IntEnum):
     RA = 0
     T1 = auto()
+
+
+# ePMP machine security configuration
+class mseccfg_reg_t(IntEnum):
+    rlb = 1b1
+    mmwp = 1b0
+    mml = 1b0
 
 
 # PMP address matching mode

--- a/src/riscv_instr_pkg.sv
+++ b/src/riscv_instr_pkg.sv
@@ -1210,6 +1210,13 @@ package riscv_instr_pkg;
 
   `include "riscv_core_setting.sv"
 
+  // ePMP machine security configuration
+  typedef struct packed {
+    bit rlb;
+    bit mmwp;
+    bit mml;
+  } mseccfg_reg_t;
+
   // PMP address matching mode
   typedef enum bit [1:0] {
     OFF   = 2'b00,

--- a/src/riscv_privil_reg.sv
+++ b/src/riscv_privil_reg.sv
@@ -264,6 +264,20 @@ class riscv_privil_reg extends riscv_reg#(privileged_reg_t);
         privil_level = M_LEVEL;
         add_field("VALUE",  XLEN,  WARL);
       end
+      // Machine security configuration
+      MSECCFG: begin
+        privil_level = M_LEVEL;
+        add_field("MML", 1, WARL); // RW1S
+        add_field("MMWP", 1, WARL); // RW1S
+        add_field("RLB", 1, WARL); // RW0C
+      end
+      // Machine security configuration, RV32 only
+      MSECCFGH: begin
+        privil_level = M_LEVEL;
+        if(XLEN!=32) begin
+          `uvm_fatal(`gfn, "CSR MSECCFGH only exists in RV32.")
+        end
+      end
       // Physical Memory Protection Configuration Register
       PMPCFG0: begin
         privil_level = M_LEVEL;

--- a/target/ml/riscv_core_setting.sv
+++ b/target/ml/riscv_core_setting.sv
@@ -42,6 +42,9 @@ int max_interrupt_vector_num = 16;
 // Physical memory protection support
 bit support_pmp = 0;
 
+// Enhanced physical memory protection support
+bit support_epmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/multi_harts/riscv_core_setting.sv
+++ b/target/multi_harts/riscv_core_setting.sv
@@ -42,6 +42,9 @@ int max_interrupt_vector_num = 16;
 // Physical memory protection support
 bit support_pmp = 0;
 
+// Enhanced physical memory protection support
+bit support_epmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/rv32i/riscv_core_setting.sv
+++ b/target/rv32i/riscv_core_setting.sv
@@ -42,6 +42,9 @@ int max_interrupt_vector_num = 16;
 // Physical memory protection support
 bit support_pmp = 0;
 
+// Enhanced physical memory protection support
+bit support_epmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/rv32imafdc/riscv_core_setting.sv
+++ b/target/rv32imafdc/riscv_core_setting.sv
@@ -42,6 +42,9 @@ int max_interrupt_vector_num = 16;
 // Physical memory protection support
 bit support_pmp = 0;
 
+// Enhanced physical memory protection support
+bit support_epmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/rv32imc/riscv_core_setting.sv
+++ b/target/rv32imc/riscv_core_setting.sv
@@ -42,6 +42,9 @@ int max_interrupt_vector_num = 16;
 // Physical memory protection support
 bit support_pmp = 0;
 
+// Enhanced physical memory protection support
+bit support_epmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/rv32imc_sv32/riscv_core_setting.sv
+++ b/target/rv32imc_sv32/riscv_core_setting.sv
@@ -42,6 +42,9 @@ int max_interrupt_vector_num = 16;
 // Physical memory protection support
 bit support_pmp = 0;
 
+// Enhanced physical memory protection support
+bit support_epmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/rv32imcb/riscv_core_setting.sv
+++ b/target/rv32imcb/riscv_core_setting.sv
@@ -42,6 +42,9 @@ int max_interrupt_vector_num = 16;
 // Physical memory protection support
 bit support_pmp = 0;
 
+// Enhanced physical memory protection support
+bit support_epmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/rv64gc/riscv_core_setting.sv
+++ b/target/rv64gc/riscv_core_setting.sv
@@ -42,6 +42,9 @@ int max_interrupt_vector_num = 16;
 // Physical memory protection support
 bit support_pmp = 0;
 
+// Enhanced physical memory protection support
+bit support_epmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/rv64gcv/riscv_core_setting.sv
+++ b/target/rv64gcv/riscv_core_setting.sv
@@ -42,6 +42,9 @@ int max_interrupt_vector_num = 16;
 // Physical memory protection support
 bit support_pmp = 0;
 
+// Enhanced physical memory protection support
+bit support_epmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/rv64imafdc/riscv_core_setting.sv
+++ b/target/rv64imafdc/riscv_core_setting.sv
@@ -42,6 +42,9 @@ int max_interrupt_vector_num = 16;
 // Physical memory protection support
 bit support_pmp = 0;
 
+// Enhanced physical memory protection support
+bit support_epmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/rv64imc/riscv_core_setting.sv
+++ b/target/rv64imc/riscv_core_setting.sv
@@ -42,6 +42,9 @@ int max_interrupt_vector_num = 16;
 // Physical memory protection support
 bit support_pmp = 0;
 
+// Enhanced physical memory protection support
+bit support_epmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 

--- a/target/rv64imcb/riscv_core_setting.sv
+++ b/target/rv64imcb/riscv_core_setting.sv
@@ -42,6 +42,9 @@ int max_interrupt_vector_num = 16;
 // Physical memory protection support
 bit support_pmp = 0;
 
+// Enhanced physical memory protection support
+bit support_epmp = 0;
+
 // Debug mode support
 bit support_debug_mode = 0;
 


### PR DESCRIPTION
This PR adds basic support for the mseccfg CSR required for ePMP. Similar to the actual PMP configuration:
- the desired configuration for mseccfg can be provided using an argument, e.g. `+mseccfg=MML:0,MMWP:0,RLB:1`.
- if randomization is turned on, it's still possible to force the bits of `mseccfg` partially or completely using this argument.
 
The CSR is only configured if the bit `support_epmp` in `riscv_core_setting.sv` is set to 1.