### PR TITLE
Allow for WFI in User Mode

### DIFF
--- a/pygen/pygen_src/riscv_instr_gen_config.py
+++ b/pygen/pygen_src/riscv_instr_gen_config.py
@@ -475,9 +475,6 @@ class riscv_instr_gen_config:
         logging.info("min_stack_len_per_program value = {}"
                      .format(self.min_stack_len_per_program))
         self.check_setting()  # check if the setting is legal
-        # WFI is not supported in umode
-        if self.init_privileged_mode == privileged_mode_t.USER_MODE:
-            self.no_wfi = 1
 
     def check_setting(self):
         support_64b = 0

--- a/src/riscv_instr_gen_config.sv
+++ b/src/riscv_instr_gen_config.sv
@@ -705,10 +705,6 @@ class riscv_instr_gen_config extends uvm_object;
     min_stack_len_per_program = 2 * (XLEN/8);
     // Check if the setting is legal
     check_setting();
-    // WFI is not supported in umode
-    if (init_privileged_mode == USER_MODE) begin
-      no_wfi = 1'b1;
-    end
   endfunction
 
   virtual function void check_setting();


### PR DESCRIPTION
This commit allows the case because if mstatus.tw is low, WFI behaviour
will not change regarding the mode. If it's set to one, it will act like
an illegal instruction. That is also not a problem because we already
generate illegal instruction handler inside gen_all_trap_handler method.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>