### PR TITLE
[pmp] Add knob to suppress PMP setup code

### DIFF
--- a/src/riscv_asm_program_gen.sv
+++ b/src/riscv_asm_program_gen.sv
@@ -829,8 +829,15 @@ class riscv_asm_program_gen extends uvm_object;
   virtual function void setup_pmp(int hart);
     string instr[$];
     if (riscv_instr_pkg::support_pmp) begin
-      cfg.pmp_cfg.setup_pmp();
-      cfg.pmp_cfg.gen_pmp_instr('{cfg.scratch_reg, cfg.gpr[0]}, instr);
+      if(cfg.pmp_cfg.suppress_pmp_setup) begin
+        // When PMP setup is suppressed generate a configuration that gives unrestricted access to
+        // all memory for both M and U mode
+        cfg.pmp_cfg.gen_pmp_enable_all(cfg.scratch_reg, instr);
+      end else begin
+        cfg.pmp_cfg.setup_pmp();
+        cfg.pmp_cfg.gen_pmp_instr('{cfg.scratch_reg, cfg.gpr[0]}, instr);
+      end
+
       gen_section(get_label("pmp_setup", hart), instr);
     end
   endfunction


### PR DESCRIPTION
By default PMP setup is included in every test which sets up a full set
of PMP regions. A test may wish to have full access to all of memory to
ensure there are no PMP failures.  This knob suppresses the general PMP
setup generation and instead generates a setup with a single region
giving full access to all of memory.