### PR TITLE
Add plusarg to enable ECALL in main randomized body

### DIFF
--- a/src/isa/riscv_instr.sv
+++ b/src/isa/riscv_instr.sv
@@ -161,6 +161,9 @@ class riscv_instr extends uvm_object;
         end
       end
     end
+    if (!cfg.no_ecall) begin
+      basic_instr = {basic_instr, ECALL};
+    end
     if (cfg.no_dret == 0) begin
       basic_instr = {basic_instr, DRET};
     end

--- a/src/riscv_instr_gen_config.sv
+++ b/src/riscv_instr_gen_config.sv
@@ -161,6 +161,8 @@ class riscv_instr_gen_config extends uvm_object;
   bit                    no_load_store;      // No load/store instruction
   bit                    no_csr_instr;       // No csr instruction
   bit                    no_ebreak = 1;      // No ebreak instruction
+  // Only enable ecall if you have overriden the test_done mechanism.
+  bit                    no_ecall = 1;       // No ecall instruction
   bit                    no_dret = 1;        // No dret instruction
   bit                    no_fence;           // No fence instruction
   bit                    no_wfi = 1;         // No WFI instruction
@@ -485,6 +487,7 @@ class riscv_instr_gen_config extends uvm_object;
     `uvm_field_int(no_load_store, UVM_DEFAULT)
     `uvm_field_int(no_csr_instr, UVM_DEFAULT)
     `uvm_field_int(no_ebreak, UVM_DEFAULT)
+    `uvm_field_int(no_ecall, UVM_DEFAULT)
     `uvm_field_int(no_dret, UVM_DEFAULT)
     `uvm_field_int(no_fence, UVM_DEFAULT)
     `uvm_field_int(no_wfi, UVM_DEFAULT)
@@ -552,6 +555,7 @@ class riscv_instr_gen_config extends uvm_object;
     get_int_arg_value("+num_of_sub_program=", num_of_sub_program);
     get_int_arg_value("+instr_cnt=", instr_cnt);
     get_bool_arg_value("+no_ebreak=", no_ebreak);
+    get_bool_arg_value("+no_ecall=", no_ecall);
     get_bool_arg_value("+no_dret=", no_dret);
     get_bool_arg_value("+no_wfi=", no_wfi);
     get_bool_arg_value("+no_branch_jump=", no_branch_jump);


### PR DESCRIPTION
Adding ECALL to the main randomized body allows us to get coverage over this instruction, but requires you to rethink how the test_done mechanism works. Currently the ECALL handler is responsible for cleanup and jumping to the end-of-test loop, so if you don't change this mechanism the test will end upon reaching the first ECALL instruction.
e.g. override the gen_test_done method in combination with enabling this option.

@ctopal @GregAC 