### PR TITLE
[pmp] Add option to constrain addresses to stay in 32-bit space

### DIFF
--- a/src/riscv_pmp_cfg.sv
+++ b/src/riscv_pmp_cfg.sv
@@ -50,6 +50,14 @@ class riscv_pmp_cfg extends uvm_object;
   // ePMP machine security configuration - RLB, MMWP, MML
   rand mseccfg_reg_t mseccfg = '{1'b1, 1'b0, 1'b0};
 
+  // allow regions that start above 32-bit address space when XLEN == 32
+  rand bit allow_high_addrs;
+
+  // percentage of configs that will allow high address regions. Set low by default as for cores
+  // where physical addresses do not go beyond 32 bits high regions don't do anything interesting
+  // (though you want some to ensure they're handled correctly).
+  int high_addr_proportion = 10;
+
   // pmp CSR configurations
   rand pmp_cfg_reg_t pmp_cfg[];
 
@@ -99,10 +107,22 @@ class riscv_pmp_cfg extends uvm_object;
     }
   }
 
+  constraint allow_high_addrs_c {
+    allow_high_addrs dist { 0 := 100 - high_addr_proportion,
+                            1 := high_addr_proportion };
+    if (XLEN == 64) {
+      allow_high_addrs == 1'b1;
+    }
+  }
+
   constraint address_modes_c {
     foreach (pmp_cfg[i]) {
       pmp_cfg[i].addr_mode >= 0;
-      pmp_cfg[i].addr_mode <= XLEN;
+      if (allow_high_addrs) {
+        pmp_cfg[i].addr_mode <= XLEN;
+      } else {
+        pmp_cfg[i].addr_mode <= XLEN - 3;
+      }
     }
   }
 
@@ -125,6 +145,7 @@ class riscv_pmp_cfg extends uvm_object;
 
   constraint modes_before_addr_c {
     foreach (pmp_cfg[i]) {
+      solve allow_high_addrs before pmp_cfg[i].addr, pmp_cfg[i].addr_mode;
       solve pmp_cfg[i].a before pmp_cfg[i].addr;
       solve pmp_cfg[i].addr_mode before pmp_cfg[i].addr;
     }
@@ -136,6 +157,10 @@ class riscv_pmp_cfg extends uvm_object;
       // remove the constraint for 1 in every XLEN entries.
       if (i > 0 && pmp_cfg[i].a == TOR && (!pmp_allow_illegal_tor || pmp_cfg[i].addr_mode > 0)) {
         pmp_cfg[i].addr > pmp_cfg[i-1].addr;
+      }
+
+      if (!allow_high_addrs) {
+        pmp_cfg[i].addr[31:29] == '0;
       }
     }
   }
@@ -150,6 +175,20 @@ class riscv_pmp_cfg extends uvm_object;
         if (pmp_cfg[i].addr_mode < XLEN) {
           // Unless the largest region is selected make sure the bit just before the ones is set to 0.
           (pmp_cfg[i].addr & (1 << pmp_cfg[i].addr_mode)) == 0;
+        }
+
+        if (!allow_high_addrs) {
+          pmp_cfg[i].addr[31:29] == '0;
+        }
+      }
+    }
+  }
+
+  constraint addr_na4_mode_c {
+    foreach (pmp_cfg[i]) {
+      if (pmp_cfg[i].a == NA4) {
+        if (!allow_high_addrs) {
+          pmp_cfg[i].addr[31:29] == '0;
         }
       }
     }


### PR DESCRIPTION
PMP supports up to 35 bits of physical address space when XLEN==32. For cores where this higher address space doesn't exist there is limited value in testing PMP settings that use it. This introduces a way to bias PMP configs so that the majority stay within the 32-bit space.