### PR TITLE
[pmp] Ensure MML PMP configurations don't dominate.

### DIFF
--- a/src/riscv_pmp_cfg.sv
+++ b/src/riscv_pmp_cfg.sv
@@ -103,6 +103,7 @@ class riscv_pmp_cfg extends uvm_object;
 
   constraint xwr_c {
     foreach (pmp_cfg[i]) {
+      solve mseccfg.mml before pmp_cfg[i].w, pmp_cfg[i].r;
       !(!mseccfg.mml && pmp_cfg[i].w && !pmp_cfg[i].r);
     }
   }


### PR DESCRIPTION
A constraint prevents MML being disabled when region configurations with W == 1 and R == 0 exist (this combination is reserved when MML is disabled).  This has the effect of making configurations with MML disabled rare as many random configurations will have at least one region with W == 1 and R == 0.

Add a solve before constraint so MML is decided upon before the W and R are randomized to more evenly generate MML and non-MML configurations.