### PR TITLE
FIX sp calculation

### DIFF
--- a/src/riscv_directed_instr_lib.sv
+++ b/src/riscv_directed_instr_lib.sv
@@ -372,7 +372,7 @@ class riscv_pop_stack_instr extends riscv_rand_instr_stream;
   function void init();
     reserved_rd = {cfg.ra};
     num_of_reg_to_save = saved_regs.size();
-    if(num_of_reg_to_save * 4 > stack_len) begin
+    if(num_of_reg_to_save * (XLEN/8) > stack_len) begin
       `uvm_fatal(get_full_name(), $sformatf("stack len [%0d] is not enough to store %d regs",
                  stack_len, num_of_reg_to_save))
     end

--- a/src/riscv_instr_pkg.sv
+++ b/src/riscv_instr_pkg.sv
@@ -1380,7 +1380,7 @@ package riscv_instr_pkg;
     string store_instr = (XLEN == 32) ? "sw" : "sd";
     if (scratch inside {implemented_csr}) begin
       // Push USP from gpr.SP onto the kernel stack
-      instr.push_back($sformatf("addi x%0d, x%0d, -4", tp, tp));
+      instr.push_back($sformatf("addi x%0d, x%0d, -%0d", tp, tp, XLEN/8));
       instr.push_back($sformatf("%0s  x%0d, (x%0d)", store_instr, sp, tp));
       // Move KSP to gpr.SP
       instr.push_back($sformatf("add x%0d, x%0d, zero", sp, tp));
@@ -1435,7 +1435,7 @@ package riscv_instr_pkg;
       instr.push_back($sformatf("add x%0d, x%0d, zero", tp, sp));
       // Pop USP from the kernel stack, move back to gpr.SP
       instr.push_back($sformatf("%0s  x%0d, (x%0d)", load_instr, sp, tp));
-      instr.push_back($sformatf("addi x%0d, x%0d, 4", tp, tp));
+      instr.push_back($sformatf("addi x%0d, x%0d, %0d", tp, tp, XLEN/8));
     end
   endfunction
 


### PR DESCRIPTION
Some stack calculations are based on a 32-bit assumption. Therefore, in 64-bit environments, unaligned accesses occur.
This commit is based on the previous pull request [Fix XLEN assumption in riscv_instr_pkg#925](https://github.com/chipsalliance/riscv-dv/pull/925),