### PR TITLE
imp module removed in Python 3.12

### DIFF
--- a/pygen/pygen_src/isa/riscv_instr.py
+++ b/pygen/pygen_src/isa/riscv_instr.py
@@ -15,7 +15,10 @@ import copy
 import sys
 import random
 import vsc
-from imp import reload
+if sys.version_info >= (3, 12):
+    from importlib import reload
+else
+    from imp import reload
 from collections import defaultdict
 from bitstring import BitArray
 from importlib import import_module

--- a/pygen/pygen_src/isa/riscv_instr.py
+++ b/pygen/pygen_src/isa/riscv_instr.py
@@ -17,7 +17,7 @@ import random
 import vsc
 if sys.version_info >= (3, 12):
     from importlib import reload
-else
+else:
     from imp import reload
 from collections import defaultdict
 from bitstring import BitArray


### PR DESCRIPTION
For backward compatibility, using conditional imports. (sys.version_info >= (3, 12))
This commit is based on the previous pull request [updated for python 3.12#985
](https://github.com/chipsalliance/riscv-dv/pull/985).